### PR TITLE
ci: add release integrity gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11', '3.12']
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[dev]'
+
+      - name: Compile Python files
+        run: python -m compileall -q custom_components plugins tests scripts
+
+      - name: Run tests
+        run: python -m pytest -q
+
+      - name: Build package artifacts
+        run: python -m build --sdist --wheel
+
+      - name: Check release integrity
+        run: python scripts/check_release_integrity.py
+
+      - name: Check release tag matches package version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: python scripts/check_release_integrity.py --tag "${GITHUB_REF_NAME}"
+
+      - name: Upload built artifacts
+        if: startsWith(github.ref, 'refs/tags/v') && matrix.python-version == '3.12'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dist
+          path: dist/*

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ This repository is a bundle of three pieces:
 | Hermes Home Assistant plugin | `plugins/home_assistant/` | Gives Hermes tools for entity search, state lookup, service calls, bulk control, scene/script discovery, and HA context. |
 | Hermes voice-stack plugin | `plugins/voice_stack/` | Adds wake-word, speech-to-text, text-to-speech, and voice pipeline helpers. |
 
+| Install target | Mechanism | Artifact/source | Current maturity |
+|---|---|---|---|
+| HA custom integration | HACS custom repository or manual copy | GitHub tag/source distribution, `custom_components/hermes/` | Supported |
+| Hermes plugins | Copy into `~/.hermes/plugins` or install the Python wheel | Wheel/source distribution, `plugins/*` | Supported |
+| HA add-on | Home Assistant Supervisor add-on scaffold | GitHub tag/source distribution, `addon/` | Early scaffold |
+
+The Python wheel is intentionally plugin-focused. Use the GitHub tag or source distribution for the full HACS/custom-component/add-on bundle.
+
 > **Release:** `v0.0.5` — ships runtime Home Assistant translations so the setup form explains exactly what the Hermes URL and token fields mean.
 
 ---
@@ -486,7 +494,7 @@ EOF
 
 ---
 
-## Step 10 — Optional Home Assistant add-on
+## Step 11 — Optional Home Assistant add-on
 
 This repository includes an early HA add-on scaffold in `addon/`. Use it if you want Hermes voice services to run under Home Assistant Supervisor instead of a separate machine.
 
@@ -585,6 +593,14 @@ Build package metadata:
 ```bash
 python -m build --sdist --wheel
 ```
+
+Run release integrity checks:
+
+```bash
+python scripts/check_release_integrity.py
+```
+
+See [`docs/release.md`](docs/release.md) for the full release checklist and artifact semantics.
 
 The tests are mocked and do not require a live Home Assistant instance.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,60 @@
+# Release process
+
+This repository ships three installation surfaces:
+
+| Surface | Source | Release expectation |
+|---|---|---|
+| Home Assistant custom integration | `custom_components/hermes/` | Installed by HACS/manual copy from the GitHub release/tag. |
+| Hermes plugins | `plugins/home_assistant/`, `plugins/voice_stack/` | Included in the Python wheel and source distribution. |
+| Home Assistant add-on scaffold | `addon/` | Included in the source distribution and GitHub tag; treated as an early scaffold until add-on CI is expanded. |
+
+The Python wheel is intentionally plugin-focused. The source distribution and GitHub tag contain the full bundle, including the Home Assistant custom component, add-on scaffold, docs, and skills.
+
+## Maintainer checklist
+
+1. Update code and tests on a feature branch.
+2. Update `CHANGELOG.md` with the next version.
+3. Sync version metadata in:
+   - `pyproject.toml`
+   - `custom_components/hermes/manifest.json`
+   - `addon/config.yaml`
+   - `plugins/home_assistant/plugin.yaml`
+   - `plugins/voice_stack/plugin.yaml`
+   - README release line
+4. Run local verification:
+
+   ```bash
+   python -m compileall -q custom_components plugins tests scripts
+   python -m pytest -q
+   python -m build --sdist --wheel
+   python scripts/check_release_integrity.py
+   ```
+
+5. Open and merge the PR after CI is green.
+6. Tag from `main`:
+
+   ```bash
+   git fetch --tags origin
+   git checkout main
+   git pull --ff-only origin main
+   git tag -a vX.Y.Z -m "vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+
+7. Create a GitHub release with the built artifacts and release notes.
+8. Verify the release:
+
+   ```bash
+   gh release view vX.Y.Z --json tagName,name,url,isDraft,isPrerelease,assets
+   python scripts/check_release_integrity.py --tag vX.Y.Z
+   ```
+
+## CI gates
+
+The CI workflow runs on pull requests, `main`, and version tags. It verifies:
+
+- Python compilation
+- pytest suite
+- wheel/source distribution build
+- metadata/version integrity
+- tag/version match for `v*` tags

--- a/scripts/check_release_integrity.py
+++ b/scripts/check_release_integrity.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Release integrity checks for hermes-voice-ha-integration.
+
+The project ships several installation surfaces (HACS custom component,
+Hermes plugins, Home Assistant add-on scaffold, and Python package artifacts).
+This script keeps release metadata and required files in sync.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore[no-redef]
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - dev extras install PyYAML
+    yaml = None  # type: ignore[assignment]
+
+ROOT = Path(__file__).resolve().parents[1]
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$")
+
+VERSION_FILES = {
+    "pyproject.toml": ("toml", ("project", "version")),
+    "custom_components/hermes/manifest.json": ("json", ("version",)),
+    "addon/config.yaml": ("yaml", ("version",)),
+    "plugins/home_assistant/plugin.yaml": ("yaml", ("version",)),
+    "plugins/voice_stack/plugin.yaml": ("yaml", ("version",)),
+}
+
+REQUIRED_FILES = [
+    "hacs.json",
+    "custom_components/hermes/__init__.py",
+    "custom_components/hermes/config_flow.py",
+    "custom_components/hermes/const.py",
+    "custom_components/hermes/frontend.py",
+    "custom_components/hermes/hacsfiles/hermes_action_bar.js",
+    "custom_components/hermes/manifest.json",
+    "custom_components/hermes/services.yaml",
+    "custom_components/hermes/strings.json",
+    "custom_components/hermes/translations/en.json",
+    "custom_components/hermes/brand/icon.png",
+    "custom_components/hermes/brand/icon@2x.png",
+    "custom_components/hermes/brand/logo.png",
+    "custom_components/hermes/brand/logo@2x.png",
+    "addon/config.yaml",
+    "addon/build.yaml",
+    "addon/Dockerfile",
+    "addon/run.sh",
+    "plugins/home_assistant/plugin.yaml",
+    "plugins/voice_stack/plugin.yaml",
+    "skills/homescript/SKILL.md",
+]
+
+WHEEL_REQUIRED = [
+    "plugins/home_assistant/plugin.yaml",
+    "plugins/home_assistant/README.md",
+    "plugins/voice_stack/plugin.yaml",
+    "plugins/voice_stack/README.md",
+]
+
+SDIST_REQUIRED = REQUIRED_FILES + ["README.md", "CHANGELOG.md", "pyproject.toml"]
+
+
+def _load_structured(path: str) -> object:
+    full = ROOT / path
+    suffix = full.suffix.lower()
+    if suffix == ".json":
+        return json.loads(full.read_text())
+    if suffix in {".yaml", ".yml"}:
+        if yaml is None:
+            raise AssertionError("PyYAML is required to parse YAML release metadata")
+        return yaml.safe_load(full.read_text())
+    if suffix == ".toml":
+        return tomllib.loads(full.read_text())
+    raise AssertionError(f"Unsupported structured file: {path}")
+
+
+def _get_path(data: object, keys: tuple[str, ...]) -> object:
+    current = data
+    for key in keys:
+        if not isinstance(current, dict) or key not in current:
+            raise AssertionError(f"Missing key {'.'.join(keys)}")
+        current = current[key]
+    return current
+
+
+def canonical_version() -> str:
+    data = _load_structured("pyproject.toml")
+    version = _get_path(data, ("project", "version"))
+    if not isinstance(version, str) or not VERSION_RE.match(version):
+        raise AssertionError(f"Invalid pyproject version: {version!r}")
+    return version
+
+
+def check_versions(tag: str | None = None) -> list[str]:
+    errors: list[str] = []
+    expected = canonical_version()
+    for rel_path, (_kind, keys) in VERSION_FILES.items():
+        try:
+            value = _get_path(_load_structured(rel_path), keys)
+        except Exception as exc:  # noqa: BLE001 - aggregate all errors
+            errors.append(f"{rel_path}: cannot read version: {exc}")
+            continue
+        if value != expected:
+            errors.append(f"{rel_path}: version {value!r} != pyproject {expected!r}")
+    if tag:
+        clean_tag = tag[1:] if tag.startswith("v") else tag
+        if clean_tag != expected:
+            errors.append(f"tag {tag!r} does not match pyproject version {expected!r}")
+    return errors
+
+
+def check_docs() -> list[str]:
+    version = canonical_version()
+    errors: list[str] = []
+    changelog = (ROOT / "CHANGELOG.md").read_text()
+    if f"## [{version}]" not in changelog:
+        errors.append(f"CHANGELOG.md missing top-level entry for {version}")
+    readme = (ROOT / "README.md").read_text()
+    if f"v{version}" not in readme:
+        errors.append(f"README.md missing release reference v{version}")
+    return errors
+
+
+def check_required_files() -> list[str]:
+    errors: list[str] = []
+    for rel_path in REQUIRED_FILES:
+        if not (ROOT / rel_path).exists():
+            errors.append(f"missing required file: {rel_path}")
+    for rel_path in ("hacs.json", "custom_components/hermes/manifest.json", "custom_components/hermes/strings.json", "custom_components/hermes/translations/en.json"):
+        try:
+            _load_structured(rel_path)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"{rel_path}: parse failed: {exc}")
+    for rel_path in ("addon/config.yaml", "addon/build.yaml", "plugins/home_assistant/plugin.yaml", "plugins/voice_stack/plugin.yaml"):
+        try:
+            _load_structured(rel_path)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"{rel_path}: parse failed: {exc}")
+    return errors
+
+
+def check_translations() -> list[str]:
+    strings = _load_structured("custom_components/hermes/strings.json")
+    translations = _load_structured("custom_components/hermes/translations/en.json")
+    if strings != translations:
+        return ["custom_components/hermes/translations/en.json must match strings.json"]
+    return []
+
+
+def _normalise_sdist_name(name: str) -> str:
+    parts = name.split("/", 1)
+    return parts[1] if len(parts) == 2 else name
+
+
+def check_artifacts() -> list[str]:
+    errors: list[str] = []
+    dist = ROOT / "dist"
+    wheels = sorted(dist.glob("*.whl"))
+    sdists = sorted(dist.glob("*.tar.gz"))
+    if not wheels or not sdists:
+        return ["dist/ must contain freshly built wheel and sdist artifacts"]
+
+    wheel = wheels[-1]
+    with zipfile.ZipFile(wheel) as zf:
+        names = set(zf.namelist())
+    for rel_path in WHEEL_REQUIRED:
+        if rel_path not in names:
+            errors.append(f"{wheel.name}: missing plugin runtime file {rel_path}")
+
+    sdist = sdists[-1]
+    with tarfile.open(sdist) as tf:
+        names = {_normalise_sdist_name(n) for n in tf.getnames()}
+    for rel_path in SDIST_REQUIRED:
+        if rel_path not in names:
+            errors.append(f"{sdist.name}: missing bundle file {rel_path}")
+    return errors
+
+
+def run_checks(tag: str | None = None, artifacts: bool = True) -> list[str]:
+    errors: list[str] = []
+    errors.extend(check_versions(tag))
+    errors.extend(check_docs())
+    errors.extend(check_required_files())
+    errors.extend(check_translations())
+    if artifacts:
+        errors.extend(check_artifacts())
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", help="Release tag to compare with the canonical version, e.g. v0.1.0")
+    parser.add_argument("--no-artifacts", action="store_true", help="Skip dist/ wheel+sdist content checks")
+    args = parser.parse_args()
+
+    errors = run_checks(tag=args.tag, artifacts=not args.no_artifacts)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print(f"release integrity ok: v{canonical_version()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_integrity.py
+++ b/tests/test_release_integrity.py
@@ -1,0 +1,48 @@
+"""Release and packaging integrity tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "scripts" / "check_release_integrity.py"
+
+spec = importlib.util.spec_from_file_location("check_release_integrity", SCRIPT_PATH)
+assert spec and spec.loader
+release_check = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(release_check)
+
+
+def test_all_release_versions_match_pyproject() -> None:
+    assert release_check.check_versions() == []
+
+
+def test_changelog_and_readme_reference_current_version() -> None:
+    assert release_check.check_docs() == []
+
+
+def test_required_hacs_component_and_addon_files_exist_and_parse() -> None:
+    assert release_check.check_required_files() == []
+
+
+def test_runtime_translation_file_matches_strings_json() -> None:
+    assert release_check.check_translations() == []
+
+
+def test_release_integrity_script_passes_without_artifacts() -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--no-artifacts"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+def test_release_artifacts_contain_expected_install_targets() -> None:
+    subprocess.run([sys.executable, "-m", "build", "--sdist", "--wheel"], cwd=ROOT, check=True)
+    assert release_check.check_artifacts() == []


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI for compile, pytest, build, and release-integrity checks.
- Add `scripts/check_release_integrity.py` plus pytest coverage for version/file/artifact invariants.
- Document artifact semantics and release workflow in `docs/release.md` and README.

## Verification
- [x] `python -m compileall -q custom_components plugins tests scripts`
- [x] `python -m pytest -q` (103 passed)
- [x] `python -m build --sdist --wheel`
- [x] `python scripts/check_release_integrity.py`
- [x] `git diff --check`
- [x] Independent release-blocker review after initial untracked-file warning; files committed before PR.

Closes #4
