### PR TITLE
feat: structure HA services and option wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to `hermes-voice-ha-integration`.
 
+## [Unreleased]
+
+### Added
+- Added structured service responses and runtime schemas for `hermes.hermes_command` and `hermes.voice_settings`.
+- Added tests for Home Assistant service response handling, voice settings queries, option wiring, and entry-scoped sensor IDs.
+
+### Fixed
+- Passed configured TTS/STT/wake-word/media-player options into the Home Assistant `HermesBridge` instead of always using bridge defaults.
+- Preserved page-1 options-flow values when saving page-2 voice settings.
+- Normalized wake-word options to a list consistently before storing or forwarding them.
+- Scoped status sensor unique IDs by config entry to avoid collisions with multiple Hermes integrations.
+
 ## [0.0.5] — 2026-05-25
 
 ### Fixed

--- a/custom_components/hermes/__init__.py
+++ b/custom_components/hermes/__init__.py
@@ -18,12 +18,12 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_URL, CONF_TOKEN, Platform
-from homeassistant.core import HomeAssistant, ServiceResponse
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN, CONF_ENTITY_FILTER, DEFAULT_ENTITY_FILTER, CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL, CONF_TTS_ENGINE, DEFAULT_TTS_ENGINE, CONF_TTS_VOICE, DEFAULT_TTS_VOICE, CONF_STT_ENGINE, DEFAULT_STT_ENGINE, CONF_STT_MODEL, DEFAULT_STT_MODEL, CONF_WAKE_WORD_ENGINE, DEFAULT_WAKE_WORD_ENGINE, CONF_WAKE_WORD, DEFAULT_WAKE_WORD, CONF_MEDIA_PLAYER, DEFAULT_MEDIA_PLAYER
+from .const import DOMAIN, CONF_ENTITY_FILTER, DEFAULT_ENTITY_FILTER, CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL, CONF_TTS_ENGINE, DEFAULT_TTS_ENGINE, CONF_TTS_VOICE, DEFAULT_TTS_VOICE, CONF_STT_ENGINE, DEFAULT_STT_ENGINE, CONF_STT_MODEL, DEFAULT_STT_MODEL, CONF_WAKE_WORD_ENGINE, DEFAULT_WAKE_WORD_ENGINE, CONF_WAKE_WORD, DEFAULT_WAKE_WORD, CONF_MEDIA_PLAYER, DEFAULT_MEDIA_PLAYER, normalize_wake_word
 from .frontend import async_register_resources as _register_frontend
 
 _LOGGER = logging.getLogger(__name__)
@@ -50,7 +50,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entity_filter = options.get(CONF_ENTITY_FILTER, entry.data.get(CONF_ENTITY_FILTER, DEFAULT_ENTITY_FILTER))
     verify_ssl = options.get(CONF_VERIFY_SSL, entry.data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL))
 
-    bridge = HermesBridge(hass, url, token, entity_filter, verify_ssl)
+    bridge = HermesBridge(
+        hass,
+        url,
+        token,
+        entity_filter,
+        verify_ssl,
+        tts_engine=options.get(CONF_TTS_ENGINE, entry.data.get(CONF_TTS_ENGINE, DEFAULT_TTS_ENGINE)),
+        tts_voice=options.get(CONF_TTS_VOICE, entry.data.get(CONF_TTS_VOICE, DEFAULT_TTS_VOICE)),
+        stt_engine=options.get(CONF_STT_ENGINE, entry.data.get(CONF_STT_ENGINE, DEFAULT_STT_ENGINE)),
+        stt_model=options.get(CONF_STT_MODEL, entry.data.get(CONF_STT_MODEL, DEFAULT_STT_MODEL)),
+        wake_word_engine=options.get(CONF_WAKE_WORD_ENGINE, entry.data.get(CONF_WAKE_WORD_ENGINE, DEFAULT_WAKE_WORD_ENGINE)),
+        wake_word=options.get(CONF_WAKE_WORD, entry.data.get(CONF_WAKE_WORD, DEFAULT_WAKE_WORD)),
+        media_player_entity=options.get(CONF_MEDIA_PLAYER, entry.data.get(CONF_MEDIA_PLAYER, DEFAULT_MEDIA_PLAYER)),
+    )
     hass.data[DOMAIN][entry.entry_id] = bridge
 
     # Connect WebSocket to Hermes Agent
@@ -113,7 +126,7 @@ class HermesBridge:
         stt_engine: str = DEFAULT_STT_ENGINE,
         stt_model: str = DEFAULT_STT_MODEL,
         wake_word_engine: str = DEFAULT_WAKE_WORD_ENGINE,
-        wake_word: str = DEFAULT_WAKE_WORD,
+        wake_word: str | list[str] = DEFAULT_WAKE_WORD,
         media_player_entity: str = DEFAULT_MEDIA_PLAYER,
     ) -> None:
         self.hass = hass
@@ -126,7 +139,7 @@ class HermesBridge:
         self.stt_engine = stt_engine
         self.stt_model = stt_model
         self.wake_word_engine = wake_word_engine
-        self.wake_word = wake_word
+        self.wake_word = normalize_wake_word(wake_word)
         self.media_player_entity = media_player_entity
         self._session: Any = None
         self._ws: Any = None
@@ -248,7 +261,21 @@ class HermesBridge:
         """Relay a Hermes voice/control command over the Hermes WebSocket."""
         _LOGGER.debug("Hermes command received: %s", command)
         action = str(command.get("action", "")).lower()
-        payload = {"type": "voice_action", "action": action}
+        payload = {
+            "type": "voice_action",
+            "action": action,
+            "media_player_entity": command.get("media_player_entity", self.media_player_entity),
+            "args": {
+                "tts_engine": self.tts_engine,
+                "tts_voice": self.tts_voice,
+                "stt_engine": self.stt_engine,
+                "stt_model": self.stt_model,
+                "wake_word_engine": self.wake_word_engine,
+                "wake_word": self.wake_word,
+                "media_player_entity": command.get("media_player_entity", self.media_player_entity),
+                **dict(command.get("args") or {}),
+            },
+        }
 
         if action == "enable":
             self._voice_ready = True

--- a/custom_components/hermes/config_flow.py
+++ b/custom_components/hermes/config_flow.py
@@ -19,16 +19,13 @@ from .const import (
     CONF_WAKE_WORD, DEFAULT_WAKE_WORD,
     CONF_MEDIA_PLAYER, DEFAULT_MEDIA_PLAYER,
     TTS_ENGINE_OPTIONS, STT_ENGINE_OPTIONS, WAKE_WORD_ENGINE_OPTIONS,
+    normalize_list, normalize_wake_word,
 )
 
 
 def _parse_list(value) -> list[str]:
     """Accept list, tuple, or newline/comma-separated string."""
-    if value is None:
-        return []
-    if isinstance(value, (list, tuple)):
-        return [str(v).strip() for v in value if str(v).strip()]
-    return [p.strip() for p in str(value).replace("\n", ",").split(",") if p.strip()]
+    return normalize_list(value)
 
 
 def _parse_entity_filter(value) -> list[str]:
@@ -38,7 +35,7 @@ def _parse_entity_filter(value) -> list[str]:
 
 def _parse_wake_word(value) -> list[str]:
     """Wake words can be a single string or comma-separated list."""
-    return _parse_list(value)
+    return normalize_wake_word(value)
 
 
 class HermesConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -99,7 +96,7 @@ def _default_options() -> dict:
         CONF_STT_ENGINE: DEFAULT_STT_ENGINE,
         CONF_STT_MODEL: DEFAULT_STT_MODEL,
         CONF_WAKE_WORD_ENGINE: DEFAULT_WAKE_WORD_ENGINE,
-        CONF_WAKE_WORD: DEFAULT_WAKE_WORD,
+        CONF_WAKE_WORD: normalize_wake_word(DEFAULT_WAKE_WORD),
         CONF_MEDIA_PLAYER: DEFAULT_MEDIA_PLAYER,
     }
 
@@ -150,7 +147,6 @@ class HermesOptionsFlow(OptionsFlow):
         current = dict(self.config_entry.options or {})
         if self._pending:
             current.update(self._pending)
-            self._pending = None
 
         if user_input is not None:
             tts_engine = str(
@@ -192,7 +188,7 @@ class HermesOptionsFlow(OptionsFlow):
         current_tts_engine = current.get(CONF_TTS_ENGINE, DEFAULT_TTS_ENGINE)
         current_stt_engine = current.get(CONF_STT_ENGINE, DEFAULT_STT_ENGINE)
         current_ww_engine = current.get(CONF_WAKE_WORD_ENGINE, DEFAULT_WAKE_WORD_ENGINE)
-        current_ww = ", ".join(current.get(CONF_WAKE_WORD, DEFAULT_WAKE_WORD))
+        current_ww = ", ".join(normalize_wake_word(current.get(CONF_WAKE_WORD, DEFAULT_WAKE_WORD)))
         current_mp = current.get(CONF_MEDIA_PLAYER, DEFAULT_MEDIA_PLAYER)
 
         return self.async_show_form(

--- a/custom_components/hermes/const.py
+++ b/custom_components/hermes/const.py
@@ -31,6 +31,22 @@ DEFAULT_STT_MODEL = "tiny"
 DEFAULT_WAKE_WORD_ENGINE = "porcupine"
 DEFAULT_WAKE_WORD = "computer"
 DEFAULT_MEDIA_PLAYER = ""
+DEFAULT_QUERY_LIMIT = 50
+
+
+def normalize_list(value: object) -> list[str]:
+    """Normalize list-like option values from HA forms and stored options."""
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return [part.strip() for part in str(value).replace("\n", ",").split(",") if part.strip()]
+
+
+def normalize_wake_word(value: object = DEFAULT_WAKE_WORD) -> list[str]:
+    """Normalize wake-word config to a list of keyword strings."""
+    parsed = normalize_list(value)
+    return parsed or [DEFAULT_WAKE_WORD]
 
 # Valid enum values (used for select dropdowns)
 TTS_ENGINE_OPTIONS = ["edge", "piper", "elevenlabs", "openai"]

--- a/custom_components/hermes/sensor.py
+++ b/custom_components/hermes/sensor.py
@@ -113,10 +113,11 @@ class HermesStatusSensor(SensorEntity):
         self,
         coordinator: HermesStatusUpdateCoordinator,
         description: SensorEntityDescription,
+        entry_id: str,
     ) -> None:
         self._coordinator = coordinator
         self.entity_description = description
-        self._attr_unique_id = f"{DOMAIN}_{description.key}"
+        self._attr_unique_id = f"{DOMAIN}_{entry_id}_{description.key}"
         self._attr_has_entity_name = True
 
     @property
@@ -158,7 +159,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> bool:
     )
     await coordinator.async_config_entry_first_refresh()
 
-    entities = [HermesStatusSensor(coordinator, desc) for desc in _DESCRIPTIONS]
+    entities = [HermesStatusSensor(coordinator, desc, entry.entry_id) for desc in _DESCRIPTIONS]
     hass.data.setdefault(f"{DOMAIN}_entities", {})[entry.entry_id] = entities
     async_add_entities(entities)
     return True

--- a/custom_components/hermes/services.py
+++ b/custom_components/hermes/services.py
@@ -5,9 +5,42 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from homeassistant.core import HomeAssistant, ServiceCall
+try:
+    import voluptuous as vol
+except ModuleNotFoundError:  # pragma: no cover - Home Assistant provides voluptuous
+    class _VolFallback:
+        ALLOW_EXTRA = object()
 
-from .const import DOMAIN
+        def Schema(self, schema: Any, *args: Any, **kwargs: Any) -> Any:
+            return schema
+
+        def Required(self, key: str, *args: Any, **kwargs: Any) -> str:
+            return key
+
+        def Optional(self, key: str, *args: Any, **kwargs: Any) -> str:
+            return key
+
+        def Any(self, *args: Any, **kwargs: Any) -> Any:
+            return object
+
+    vol = _VolFallback()  # type: ignore[assignment]
+
+try:
+    from homeassistant.core import HomeAssistant, ServiceCall
+except ModuleNotFoundError:  # pragma: no cover - lets pure unit tests import helpers
+    class HomeAssistant:  # type: ignore[no-redef]
+        pass
+
+    class ServiceCall:  # type: ignore[no-redef]
+        data: dict[str, Any]
+
+try:
+    from homeassistant.core import SupportsResponse
+except (ImportError, ModuleNotFoundError):  # pragma: no cover - older HA/test stubs
+    class SupportsResponse:  # type: ignore[no-redef]
+        OPTIONAL = "optional"
+
+from .const import DEFAULT_QUERY_LIMIT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -15,56 +48,227 @@ SERVICE_HERMES_COMMAND = "hermes_command"
 SERVICE_VOICE_SETTINGS = "voice_settings"
 
 
+def _as_bool(value: Any, default: bool = False) -> bool:
+    """Parse bool-ish service values from HA forms/API calls."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _as_int(value: Any, default: int, minimum: int = 1, maximum: int = 500) -> int:
+    """Parse and clamp integer service values."""
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(minimum, min(maximum, parsed))
+
+
+def _build_target(call_data: dict[str, Any]) -> dict[str, Any] | None:
+    """Build a Home Assistant service target from entity/area/device fields."""
+    target: dict[str, Any] = {}
+    explicit = call_data.get("target")
+    if isinstance(explicit, dict):
+        target.update({k: v for k, v in explicit.items() if v not in (None, "", [])})
+    for key in ("entity_id", "area_id", "device_id"):
+        value = call_data.get(key)
+        if value not in (None, "", []):
+            target[key] = value
+    return target or None
+
+
+def _bridge_status(bridge: Any) -> dict[str, Any]:
+    """Return a compact status payload for a bridge-like object."""
+    if hasattr(bridge, "status_snapshot"):
+        snapshot = bridge.status_snapshot()
+    else:
+        snapshot = []
+    return {
+        "connected": bool(getattr(bridge, "connected", False)),
+        "voice_ready": bool(getattr(bridge, "_voice_ready", False)),
+        "status": snapshot,
+    }
+
+
+def _iter_target_bridges(hass: HomeAssistant, entry_id: str | None = None) -> list[tuple[str, Any]]:
+    """Return bridge entries targeted by a service call."""
+    entries = list(hass.data.get(DOMAIN, {}).items())
+    if entry_id:
+        entries = [(eid, bridge) for eid, bridge in entries if eid == entry_id]
+    return entries
+
+
+def _entity_matches(state: Any, query: str) -> bool:
+    """Return whether a HA state object matches a voice-settings query."""
+    friendly_name = str(getattr(state, "attributes", {}).get("friendly_name", ""))
+    haystack = f"{state.entity_id} {friendly_name}".lower()
+    return not query or query in haystack
+
+
+def _state_payload(state: Any, include_attributes: bool = True) -> dict[str, Any]:
+    """Convert a Home Assistant state object into service response data."""
+    payload = {"entity_id": state.entity_id, "state": state.state}
+    if include_attributes:
+        payload["attributes"] = dict(getattr(state, "attributes", {}) or {})
+    return payload
+
+
+COMMAND_SCHEMA = vol.Schema(
+    {
+        vol.Required("domain"): str,
+        vol.Required("service"): str,
+        vol.Optional("entity_id"): vol.Any(str, list),
+        vol.Optional("area_id"): vol.Any(str, list),
+        vol.Optional("device_id"): vol.Any(str, list),
+        vol.Optional("target"): dict,
+        vol.Optional("data", default={}): dict,
+        vol.Optional("blocking", default=True): bool,
+        vol.Optional("return_response", default=False): bool,
+    },
+    extra=getattr(vol, "ALLOW_EXTRA", True),
+)
+
+VOICE_SCHEMA = vol.Schema(
+    {
+        vol.Optional("action"): str,
+        vol.Optional("query", default=""): str,
+        vol.Optional("entry_id"): str,
+        vol.Optional("media_player_entity"): str,
+        vol.Optional("args", default={}): dict,
+        vol.Optional("limit", default=DEFAULT_QUERY_LIMIT): int,
+        vol.Optional("include_attributes", default=True): bool,
+    },
+    extra=getattr(vol, "ALLOW_EXTRA", True),
+)
+
+
 async def async_register_services(hass: HomeAssistant) -> None:
     """Register HA-native services used by the Hermes integration."""
 
-    async def _handle_hermes_command(call: ServiceCall) -> None:
-        domain = call.data.get("domain", "")
-        service = call.data.get("service", "")
-        entity_id = call.data.get("entity_id")
-        data = dict(call.data.get("data") or {})
+    async def _handle_hermes_command(call: ServiceCall) -> dict[str, Any]:
+        call_data = dict(call.data)
+        domain = str(call_data.get("domain", "")).strip()
+        service = str(call_data.get("service", "")).strip()
+        service_data = dict(call_data.get("data") or {})
+        target = _build_target(call_data)
+        blocking = _as_bool(call_data.get("blocking"), default=True)
+        return_response = _as_bool(call_data.get("return_response"), default=False)
 
         if not domain or not service:
-            _LOGGER.warning("Ignoring Hermes command with missing domain/service: %s", call.data)
-            return
+            return {"ok": False, "error": "domain_and_service_required", "domain": domain, "service": service}
 
-        target = {"entity_id": entity_id} if entity_id else None
-        await hass.services.async_call(
-            domain,
-            service,
-            data,
-            target=target,
-            blocking=False,
-        )
-        _LOGGER.info("Hermes command dispatched: %s.%s entity=%s", domain, service, entity_id)
+        if not hass.services.has_service(domain, service):
+            _LOGGER.warning("Hermes command rejected; service not found: %s.%s", domain, service)
+            return {"ok": False, "error": "service_not_found", "domain": domain, "service": service}
 
-    async def _handle_voice_settings(call: ServiceCall) -> None:
-        query = str(call.data.get("query", "")).lower().strip()
-        action = str(call.data.get("action") or query).lower().strip()
+        try:
+            try:
+                result = await hass.services.async_call(
+                    domain,
+                    service,
+                    service_data,
+                    target=target,
+                    blocking=blocking,
+                    return_response=return_response,
+                )
+            except TypeError:
+                result = await hass.services.async_call(
+                    domain,
+                    service,
+                    service_data,
+                    target=target,
+                    blocking=blocking,
+                )
+        except Exception as exc:  # noqa: BLE001 - HA integrations return structured service errors
+            _LOGGER.warning("Hermes command failed: %s.%s: %s", domain, service, exc)
+            return {
+                "ok": False,
+                "error": "service_call_failed",
+                "message": str(exc),
+                "domain": domain,
+                "service": service,
+                "target": target,
+            }
+
+        _LOGGER.info("Hermes command dispatched: %s.%s target=%s", domain, service, target)
+        response: dict[str, Any] = {
+            "ok": True,
+            "domain": domain,
+            "service": service,
+            "target": target,
+            "blocking": blocking,
+            "return_response": return_response,
+        }
+        if result is not None:
+            response["result"] = result
+        return response
+
+    async def _handle_voice_settings(call: ServiceCall) -> dict[str, Any]:
+        call_data = dict(call.data)
+        query = str(call_data.get("query", "")).lower().strip()
+        action = str(call_data.get("action") or query).lower().strip()
+        entry_id = str(call_data.get("entry_id") or "").strip() or None
+        limit = _as_int(call_data.get("limit"), DEFAULT_QUERY_LIMIT, minimum=1, maximum=500)
+        include_attributes = _as_bool(call_data.get("include_attributes"), default=True)
 
         if action in {"enable", "disable", "status"}:
-            for bridge in hass.data.get(DOMAIN, {}).values():
-                if hasattr(bridge, "async_relay_command"):
-                    await bridge.async_relay_command({"type": "voice_settings", "action": action})
-            _LOGGER.info("Hermes voice action requested: %s", action)
-            return
+            entries = _iter_target_bridges(hass, entry_id)
+            if entry_id and not entries:
+                return {"ok": False, "error": "entry_not_found", "entry_id": entry_id}
+
+            results: dict[str, Any] = {}
+            for bridge_entry_id, bridge in entries:
+                if action == "status":
+                    results[bridge_entry_id] = _bridge_status(bridge)
+                    continue
+                if not hasattr(bridge, "async_relay_command"):
+                    results[bridge_entry_id] = {"ok": False, "error": "bridge_not_relay_capable"}
+                    continue
+                media_player_entity = call_data.get("media_player_entity") or getattr(bridge, "media_player_entity", "")
+                results[bridge_entry_id] = await bridge.async_relay_command(
+                    {
+                        "type": "voice_settings",
+                        "action": action,
+                        "media_player_entity": media_player_entity,
+                        "args": dict(call_data.get("args") or {}),
+                    }
+                )
+            if action == "status":
+                ok = bool(results) or entry_id is None
+            else:
+                ok = all(result.get("ok", False) for result in results.values()) if results else False
+            _LOGGER.info("Hermes voice action requested: %s entries=%d", action, len(results))
+            return {"ok": ok, "action": action, "entry_id": entry_id, "results": results}
 
         matches: list[dict[str, Any]] = []
         for state in hass.states.async_all():
-            friendly_name = str(state.attributes.get("friendly_name", ""))
-            haystack = f"{state.entity_id} {friendly_name}".lower()
-            if not query or query in haystack:
-                matches.append({
-                    "entity_id": state.entity_id,
-                    "state": state.state,
-                    "attributes": dict(state.attributes),
-                })
+            if _entity_matches(state, query):
+                matches.append(_state_payload(state, include_attributes=include_attributes))
+                if len(matches) >= limit:
+                    break
         _LOGGER.info("Hermes voice settings query=%r matched %d entities", query, len(matches))
+        return {"ok": True, "query": query, "count": len(matches), "limit": limit, "matches": matches}
+
+    def _register_service(name: str, handler: Any, schema: Any) -> None:
+        try:
+            hass.services.async_register(
+                DOMAIN,
+                name,
+                handler,
+                schema=schema,
+                supports_response=SupportsResponse.OPTIONAL,
+            )
+        except TypeError:  # Older Home Assistant cores without service responses.
+            hass.services.async_register(DOMAIN, name, handler, schema=schema)
 
     if not hass.services.has_service(DOMAIN, SERVICE_HERMES_COMMAND):
-        hass.services.async_register(DOMAIN, SERVICE_HERMES_COMMAND, _handle_hermes_command)
+        _register_service(SERVICE_HERMES_COMMAND, _handle_hermes_command, COMMAND_SCHEMA)
     if not hass.services.has_service(DOMAIN, SERVICE_VOICE_SETTINGS):
-        hass.services.async_register(DOMAIN, SERVICE_VOICE_SETTINGS, _handle_voice_settings)
+        _register_service(SERVICE_VOICE_SETTINGS, _handle_voice_settings, VOICE_SCHEMA)
 
     _LOGGER.info("Hermes services registered: %s, %s", SERVICE_HERMES_COMMAND, SERVICE_VOICE_SETTINGS)
 

--- a/custom_components/hermes/services.yaml
+++ b/custom_components/hermes/services.yaml
@@ -3,40 +3,72 @@
 
 hermes_command:
   name: Hermes command
-  description: Execute a Home Assistant service call routed from Hermes.
+  description: Execute a Home Assistant service call routed from Hermes. Returns structured success/error data when called via APIs that request service responses.
   fields:
     domain:
       name: Domain
-      description: The service domain (e.g., light).
+      description: The service domain (for example, light).
       required: true
       selector:
         text: {}
     service:
       name: Service
-      description: The service name (e.g., turn_on).
+      description: The service name (for example, turn_on).
       required: true
       selector:
         text: {}
     entity_id:
       name: Entity ID
-      description: Optional entity_id to target.
-      required: false
-      selector:
-        text: {}
-    data:
-      name: Data
-      description: Additional service data (JSON).
+      description: Optional entity_id or entity_id list to target.
       required: false
       selector:
         object: {}
+    area_id:
+      name: Area ID
+      description: Optional area_id or area_id list to target.
+      required: false
+      selector:
+        object: {}
+    device_id:
+      name: Device ID
+      description: Optional device_id or device_id list to target.
+      required: false
+      selector:
+        object: {}
+    target:
+      name: Target
+      description: Optional raw Home Assistant target object. entity_id, area_id, and device_id fields are merged into this target.
+      required: false
+      selector:
+        object: {}
+    data:
+      name: Data
+      description: Additional service data.
+      required: false
+      selector:
+        object: {}
+    blocking:
+      name: Wait for completion
+      description: Wait for the underlying Home Assistant service call to complete before returning a response.
+      required: false
+      default: true
+      selector:
+        boolean: {}
+    return_response:
+      name: Return service response
+      description: Request response data from response-capable Home Assistant services.
+      required: false
+      default: false
+      selector:
+        boolean: {}
 
 voice_settings:
   name: Voice settings
-  description: Send a voice action to Hermes or query HA entities for voice pipeline configuration.
+  description: Send a voice action to Hermes or query HA entities for voice pipeline configuration. Returns action results or entity matches when service responses are requested.
   fields:
     action:
       name: Action
-      description: Voice action to request.
+      description: Voice action to request. `status` returns local bridge status without relaying a command.
       required: false
       selector:
         select:
@@ -44,9 +76,45 @@ voice_settings:
             - enable
             - disable
             - status
+    entry_id:
+      name: Config entry ID
+      description: Optional Hermes config entry ID to target when multiple Hermes integrations are configured.
+      required: false
+      selector:
+        text: {}
+    media_player_entity:
+      name: Media player entity
+      description: Optional media_player entity passed to Hermes when enabling voice output.
+      required: false
+      selector:
+        entity:
+          domain: media_player
+    args:
+      name: Extra voice action arguments
+      description: Optional argument object forwarded to the Hermes voice stack.
+      required: false
+      selector:
+        object: {}
     query:
       name: Query
       description: Entity search query used when no action is supplied.
       required: false
       selector:
         text: {}
+    limit:
+      name: Result limit
+      description: Maximum entity matches to return for query mode.
+      required: false
+      default: 50
+      selector:
+        number:
+          min: 1
+          max: 500
+          mode: box
+    include_attributes:
+      name: Include attributes
+      description: Include entity attributes in query responses.
+      required: false
+      default: true
+      selector:
+        boolean: {}

--- a/tests/test_ha_component_wiring.py
+++ b/tests/test_ha_component_wiring.py
@@ -1,0 +1,56 @@
+"""Static behavioural checks for the HA custom component wiring.
+
+The local test environment intentionally does not install Home Assistant. These
+checks protect HA-facing wiring that would otherwise be easy to regress while
+keeping the test suite lightweight and fully mocked.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _source(rel_path: str) -> str:
+    return (ROOT / rel_path).read_text()
+
+
+def test_async_setup_entry_passes_voice_options_to_bridge() -> None:
+    source = _source("custom_components/hermes/__init__.py")
+    tree = ast.parse(source)
+    calls = [node for node in ast.walk(tree) if isinstance(node, ast.Call) and getattr(node.func, "id", "") == "HermesBridge"]
+    assert calls, "async_setup_entry should construct HermesBridge"
+    keyword_names = {kw.arg for call in calls for kw in call.keywords}
+    assert {
+        "tts_engine",
+        "tts_voice",
+        "stt_engine",
+        "stt_model",
+        "wake_word_engine",
+        "wake_word",
+        "media_player_entity",
+    } <= keyword_names
+
+
+def test_bridge_normalizes_wake_word_and_forwards_voice_args() -> None:
+    source = _source("custom_components/hermes/__init__.py")
+    assert "self.wake_word = normalize_wake_word(wake_word)" in source
+    assert '"tts_engine": self.tts_engine' in source
+    assert '"wake_word": self.wake_word' in source
+    assert '**dict(command.get("args") or {})' in source
+
+
+def test_options_flow_preserves_pending_init_values_until_final_create() -> None:
+    source = _source("custom_components/hermes/config_flow.py")
+    voice_method = source.split("async def async_step_voice", 1)[1].split("return self.async_show_form", 1)[0]
+    assert "current.update(self._pending)" in voice_method
+    assert "self._pending = None" not in voice_method
+    assert "CONF_WAKE_WORD: normalize_wake_word(DEFAULT_WAKE_WORD)" in source
+
+
+def test_status_sensor_unique_ids_are_entry_scoped() -> None:
+    source = _source("custom_components/hermes/sensor.py")
+    assert 'self._attr_unique_id = f"{DOMAIN}_{entry_id}_{description.key}"' in source
+    assert "HermesStatusSensor(coordinator, desc, entry.entry_id)" in source

--- a/tests/test_ha_services.py
+++ b/tests/test_ha_services.py
@@ -1,0 +1,285 @@
+"""Tests for the Home Assistant custom-component service helpers."""
+
+from __future__ import annotations
+
+from types import ModuleType, SimpleNamespace
+from typing import Any
+import sys
+
+import pytest
+
+
+def _install_homeassistant_stubs() -> None:
+    """Install minimal HA module stubs so custom-component helpers can import."""
+    modules = {
+        "homeassistant": ModuleType("homeassistant"),
+        "homeassistant.config_entries": ModuleType("homeassistant.config_entries"),
+        "homeassistant.const": ModuleType("homeassistant.const"),
+        "homeassistant.core": ModuleType("homeassistant.core"),
+        "homeassistant.helpers": ModuleType("homeassistant.helpers"),
+        "homeassistant.helpers.entity": ModuleType("homeassistant.helpers.entity"),
+        "homeassistant.helpers.event": ModuleType("homeassistant.helpers.event"),
+        "homeassistant.helpers.typing": ModuleType("homeassistant.helpers.typing"),
+        "homeassistant.components": ModuleType("homeassistant.components"),
+        "homeassistant.components.http": ModuleType("homeassistant.components.http"),
+    }
+    for name, module in modules.items():
+        sys.modules.setdefault(name, module)
+    sys.modules["homeassistant.config_entries"].ConfigEntry = object
+    sys.modules["homeassistant.const"].CONF_URL = "url"
+    sys.modules["homeassistant.const"].CONF_TOKEN = "token"
+    sys.modules["homeassistant.const"].Platform = SimpleNamespace(SENSOR="sensor")
+    sys.modules["homeassistant.core"].HomeAssistant = object
+    sys.modules["homeassistant.core"].ServiceCall = object
+    sys.modules["homeassistant.core"].ServiceResponse = dict
+    sys.modules["homeassistant.core"].SupportsResponse = SimpleNamespace(OPTIONAL="optional")
+    sys.modules["homeassistant.helpers.entity"].Entity = object
+    sys.modules["homeassistant.helpers.event"].async_track_state_change_event = lambda *a, **k: (lambda: None)
+    sys.modules["homeassistant.helpers.typing"].ConfigType = dict
+    sys.modules["homeassistant.components.http"].StaticPathConfig = lambda *a, **k: (a, k)
+
+
+_install_homeassistant_stubs()
+
+from custom_components.hermes.const import DOMAIN, normalize_wake_word
+from custom_components.hermes import services as hermes_services
+
+
+class FakeServiceRegistry:
+    def __init__(self) -> None:
+        self.registered: dict[tuple[str, str], Any] = {}
+        self.schemas: dict[tuple[str, str], Any] = {}
+        self.supports_response: dict[tuple[str, str], Any] = {}
+        self.available: set[tuple[str, str]] = set()
+        self.calls: list[dict[str, Any]] = []
+        self.raise_on_call: Exception | None = None
+
+    def has_service(self, domain: str, service: str) -> bool:
+        return (domain, service) in self.available or (domain, service) in self.registered
+
+    def async_register(self, domain: str, service: str, handler: Any, **kwargs: Any) -> None:
+        self.registered[(domain, service)] = handler
+        self.schemas[(domain, service)] = kwargs.get("schema")
+        self.supports_response[(domain, service)] = kwargs.get("supports_response")
+
+    def async_remove(self, domain: str, service: str) -> None:
+        self.registered.pop((domain, service), None)
+
+    async def async_call(
+        self,
+        domain: str,
+        service: str,
+        data: dict[str, Any],
+        *,
+        target: dict[str, Any] | None,
+        blocking: bool,
+        return_response: bool = False,
+    ) -> dict[str, Any] | None:
+        if self.raise_on_call:
+            raise self.raise_on_call
+        self.calls.append({
+            "domain": domain,
+            "service": service,
+            "data": data,
+            "target": target,
+            "blocking": blocking,
+            "return_response": return_response,
+        })
+        return {"changed": True} if return_response else None
+
+
+class FakeStates:
+    def __init__(self, states: list[Any]) -> None:
+        self._states = states
+
+    def async_all(self) -> list[Any]:
+        return self._states
+
+
+class FakeHass:
+    def __init__(self) -> None:
+        self.services = FakeServiceRegistry()
+        self.states = FakeStates([])
+        self.data: dict[str, Any] = {DOMAIN: {}}
+
+
+class FakeCall:
+    def __init__(self, data: dict[str, Any]) -> None:
+        self.data = data
+
+
+class FakeBridge:
+    connected = True
+
+    def __init__(self) -> None:
+        self.commands: list[dict[str, Any]] = []
+        self._voice_ready = False
+        self.media_player_entity = "media_player.default"
+
+    async def async_relay_command(self, command: dict[str, Any]) -> dict[str, Any]:
+        self.commands.append(command)
+        return {"ok": True, "queued": False, "action": command["action"]}
+
+    def status_snapshot(self) -> list[dict[str, Any]]:
+        return [{"entity_id": "sensor.hermes_voice_ready", "state": "off", "attributes": {}}]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("computer", ["computer"]),
+        ("computer, hey jarvis\nok hermes", ["computer", "hey jarvis", "ok hermes"]),
+        ([" computer ", "", "jarvis"], ["computer", "jarvis"]),
+        (None, ["computer"]),
+    ],
+)
+def test_normalize_wake_word(value: object, expected: list[str]) -> None:
+    assert normalize_wake_word(value) == expected
+
+
+def test_target_builder_merges_entity_area_device_and_explicit_target() -> None:
+    target = hermes_services._build_target(
+        {
+            "target": {"entity_id": "light.kitchen"},
+            "area_id": "living_room",
+            "device_id": ["abc"],
+        }
+    )
+    assert target == {"entity_id": "light.kitchen", "area_id": "living_room", "device_id": ["abc"]}
+
+
+@pytest.mark.asyncio
+async def test_hermes_command_returns_structured_success() -> None:
+    hass = FakeHass()
+    hass.services.available.add(("light", "turn_on"))
+    await hermes_services.async_register_services(hass)  # type: ignore[arg-type]
+
+    handler = hass.services.registered[(DOMAIN, hermes_services.SERVICE_HERMES_COMMAND)]
+    response = await handler(
+        FakeCall(
+            {
+                "domain": "light",
+                "service": "turn_on",
+                "entity_id": "light.kitchen",
+                "data": {"brightness": 128},
+                "blocking": True,
+                "return_response": True,
+            }
+        )
+    )
+
+    assert response["ok"] is True
+    assert response["domain"] == "light"
+    assert response["service"] == "turn_on"
+    assert response["blocking"] is True
+    assert response["return_response"] is True
+    assert response["result"] == {"changed": True}
+    assert hass.services.calls == [
+        {
+            "domain": "light",
+            "service": "turn_on",
+            "data": {"brightness": 128},
+            "target": {"entity_id": "light.kitchen"},
+            "blocking": True,
+            "return_response": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_hermes_command_rejects_missing_service() -> None:
+    hass = FakeHass()
+    await hermes_services.async_register_services(hass)  # type: ignore[arg-type]
+
+    handler = hass.services.registered[(DOMAIN, hermes_services.SERVICE_HERMES_COMMAND)]
+    response = await handler(FakeCall({"domain": "light", "service": "explode"}))
+
+    assert response == {"ok": False, "error": "service_not_found", "domain": "light", "service": "explode"}
+    assert hass.services.calls == []
+
+
+@pytest.mark.asyncio
+async def test_hermes_command_returns_structured_error_on_exception() -> None:
+    hass = FakeHass()
+    hass.services.available.add(("light", "turn_on"))
+    hass.services.raise_on_call = RuntimeError("boom")
+    await hermes_services.async_register_services(hass)  # type: ignore[arg-type]
+
+    handler = hass.services.registered[(DOMAIN, hermes_services.SERVICE_HERMES_COMMAND)]
+    response = await handler(FakeCall({"domain": "light", "service": "turn_on", "area_id": "kitchen"}))
+
+    assert response["ok"] is False
+    assert response["error"] == "service_call_failed"
+    assert response["message"] == "boom"
+    assert response["target"] == {"area_id": "kitchen"}
+
+
+@pytest.mark.asyncio
+async def test_voice_settings_status_and_enable_return_per_entry_results() -> None:
+    hass = FakeHass()
+    bridge = FakeBridge()
+    hass.data[DOMAIN]["entry-1"] = bridge
+    await hermes_services.async_register_services(hass)  # type: ignore[arg-type]
+
+    handler = hass.services.registered[(DOMAIN, hermes_services.SERVICE_VOICE_SETTINGS)]
+    status = await handler(FakeCall({"action": "status", "entry_id": "entry-1"}))
+    assert status["ok"] is True
+    assert status["results"]["entry-1"]["connected"] is True
+
+    enable = await handler(
+        FakeCall(
+            {
+                "action": "enable",
+                "entry_id": "entry-1",
+                "media_player_entity": "media_player.living_room",
+                "args": {"duration": 3},
+            }
+        )
+    )
+    assert enable["ok"] is True
+    assert bridge.commands == [
+        {
+            "type": "voice_settings",
+            "action": "enable",
+            "media_player_entity": "media_player.living_room",
+            "args": {"duration": 3},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_voice_settings_enable_uses_configured_media_player_when_omitted() -> None:
+    hass = FakeHass()
+    bridge = FakeBridge()
+    hass.data[DOMAIN]["entry-1"] = bridge
+    await hermes_services.async_register_services(hass)  # type: ignore[arg-type]
+
+    handler = hass.services.registered[(DOMAIN, hermes_services.SERVICE_VOICE_SETTINGS)]
+    response = await handler(FakeCall({"action": "enable", "entry_id": "entry-1"}))
+
+    assert response["ok"] is True
+    assert bridge.commands[-1]["media_player_entity"] == "media_player.default"
+
+
+@pytest.mark.asyncio
+async def test_voice_settings_query_returns_limited_matches() -> None:
+    hass = FakeHass()
+    hass.states = FakeStates(
+        [
+            SimpleNamespace(entity_id="light.kitchen", state="on", attributes={"friendly_name": "Kitchen Light"}),
+            SimpleNamespace(entity_id="light.bedroom", state="off", attributes={"friendly_name": "Bedroom Light"}),
+            SimpleNamespace(entity_id="switch.kitchen_fan", state="off", attributes={"friendly_name": "Kitchen Fan"}),
+        ]
+    )
+    await hermes_services.async_register_services(hass)  # type: ignore[arg-type]
+
+    handler = hass.services.registered[(DOMAIN, hermes_services.SERVICE_VOICE_SETTINGS)]
+    response = await handler(FakeCall({"query": "kitchen", "limit": 1, "include_attributes": False}))
+
+    assert response == {
+        "ok": True,
+        "query": "kitchen",
+        "count": 1,
+        "limit": 1,
+        "matches": [{"entity_id": "light.kitchen", "state": "on"}],
+    }


### PR DESCRIPTION
## Summary
- Register `hermes.hermes_command` and `hermes.voice_settings` with runtime schemas and structured responses.
- Validate service existence, return structured errors, support targets, blocking calls, and optional downstream HA service responses.
- Pass configured TTS/STT/wake-word/media-player options into `HermesBridge` and forward voice action args.
- Fix options-flow pending state, normalise wake-word values, and scope status sensor unique IDs by config entry.
- Add mocked HA service tests and lightweight wiring guards.

## Verification
- [x] `python -m compileall -q custom_components plugins tests scripts`
- [x] `python -m pytest -q` (118 passed)
- [x] `python -m build --sdist --wheel`
- [x] `python scripts/check_release_integrity.py`
- [x] `git diff --check`
- [x] Multi-model review: fixed blockers for `return_response`, `SupportsResponse` import compatibility, default media-player forwarding, and stale `ServiceResponse` import.

Closes #5
