### PR TITLE
feat: harden HA websocket voice lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ All notable changes to `hermes-voice-ha-integration`.
 ### Added
 - Added structured service responses and runtime schemas for `hermes.hermes_command` and `hermes.voice_settings`.
 - Added tests for Home Assistant service response handling, voice settings queries, option wiring, and entry-scoped sensor IDs.
+- Added request ID correlation, status/health telemetry, connection/message counters, and protocol documentation for the HA→Hermes WebSocket receiver.
+- Added voice lifecycle tests covering richer HA action context, pipeline locking, cache directory creation, and categorized one-shot listen failures.
 
 ### Fixed
 - Passed configured TTS/STT/wake-word/media-player options into the Home Assistant `HermesBridge` instead of always using bridge defaults.
 - Preserved page-1 options-flow values when saving page-2 voice settings.
 - Normalized wake-word options to a list consistently before storing or forwarding them.
 - Scoped status sensor unique IDs by config entry to avoid collisions with multiple Hermes integrations.
+- Created voice-cache directories before temporary recordings and returned stable `voice_listen` error categories for invalid durations, unavailable engines, recording failures, no speech, and transcription failures.
+- Reused the voice pipeline lock across enable/disable paths so concurrent lifecycle calls cannot create multiple active pipeline instances.
 
 ## [0.0.5] — 2026-05-25
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The Python wheel is intentionally plugin-focused. Use the GitHub tag or source d
 - Let Hermes call Home Assistant services: lights, switches, scenes, scripts, climate, media players, and more.
 - Use safety controls: blocked service domains, optional allow-list, and JSON-line audit logging.
 - Expose Hermes health into HA as status sensors.
+- Bridge HA-originated voice lifecycle events over the documented WebSocket protocol (`docs/ws-protocol.md`).
 - Add a small Lovelace action bar to dashboards.
 - Build toward local voice control with configurable STT/TTS/wake-word engines.
 

--- a/docs/ws-protocol.md
+++ b/docs/ws-protocol.md
@@ -1,0 +1,119 @@
+# Hermes Home Assistant WebSocket Protocol
+
+Hermes Voice Stack exposes a small HA-facing WebSocket receiver, enabled by default at:
+
+```text
+ws://<hermes-host>:7860/api/hermes/ws
+```
+
+Set `HERMES_HA_WS_HOST`, `HERMES_HA_WS_PORT`, and `HERMES_HA_WS_PATH` to override the bind address. Set `HERMES_HA_WS_ENABLED=0` to disable it.
+
+## Authentication
+
+If any of these environment variables is set, HA must connect with an `Authorization` header using the `Bearer TOKEN` scheme:
+
+1. `HERMES_HA_WS_TOKEN`
+2. `API_SERVER_KEY`
+3. `HERMES_API_KEY`
+
+If none is set, the receiver accepts local unauthenticated connections. Production deployments should set `HERMES_HA_WS_TOKEN`.
+
+## Request correlation
+
+Every client message may include an `id` field. Hermes preserves that field in the response so HA can correlate concurrent requests.
+
+```json
+{"id":"req-1","type":"ping"}
+```
+
+```json
+{"id":"req-1","type":"pong","ok":true}
+```
+
+## Message types
+
+### `ping`
+
+Health probe over the WebSocket channel.
+
+Response: `pong`.
+
+### `status`
+
+Returns receiver health and observability data.
+
+```json
+{"id":"req-2","type":"status"}
+```
+
+```json
+{
+  "id": "req-2",
+  "type": "status",
+  "ok": true,
+  "service": "hermes-ha-ws",
+  "running": true,
+  "uptime_seconds": 42.0,
+  "auth_required": true,
+  "active_connections": 1,
+  "total_connections": 3,
+  "message_counters": {"status": 2, "voice_action": 1},
+  "host": "0.0.0.0",
+  "port": 7860,
+  "path": "/api/hermes/ws"
+}
+```
+
+The `/health` HTTP endpoint returns the same status shape without requiring a WebSocket upgrade.
+
+### `state_changed`
+
+HA can push selected state changes into Hermes. Hermes acknowledges receipt; semantic ingestion can be layered on top later.
+
+```json
+{"id":"evt-1","type":"state_changed","entity_id":"light.kitchen","state":"on"}
+```
+
+Response: `ack` with the same `entity_id`.
+
+### `voice_action`
+
+Dispatches HA-originated voice lifecycle actions to the local voice stack.
+
+Supported actions:
+
+- `enable`
+- `disable`
+- `status`
+
+Hermes forwards all top-level fields except `type`, `action`, and `args` into the handler args, then overlays the explicit `args` dictionary. This lets HA pass context such as `entry_id`, `media_player_entity`, `duration`, or `language` without losing future fields.
+
+```json
+{
+  "id": "voice-1",
+  "type": "voice_action",
+  "action": "enable",
+  "entry_id": "01J...",
+  "media_player_entity": "media_player.living_room",
+  "args": {"duration": 5}
+}
+```
+
+Response type: `voice_action_result`.
+
+## Error shape
+
+Unsupported message types and handler failures return:
+
+```json
+{"id":"req-3","type":"error","ok":false,"error":"Unsupported message type: banana"}
+```
+
+Voice-listen errors include an `error_category` field for automation-friendly branching:
+
+- `engine_unavailable`
+- `invalid_duration`
+- `cache_unavailable`
+- `no_speech`
+- `recording_failed`
+- `transcription_failed`

--- a/docs/ws-receiver.md
+++ b/docs/ws-receiver.md
@@ -34,7 +34,8 @@ ws://host:7860/api/hermes/ws ──► HermesHAWebSocketServer._handle_ws
                                     └─ _handle_voice_{enable,disable,status}
                                          └─ (returns JSON string)
   {type: "state_changed"} ──► ack()         ← context buffer | update | store        ──► Hermes event bus  ──► tool_enabled
-  {type: "ping"/"status"} ──► pong()
+  {type: "ping"} ──► pong()
+  {type: "status"} ──► status({uptime, auth_required, counters, connections})
 ```
 
 ---

--- a/plugins/voice_stack/__init__.py
+++ b/plugins/voice_stack/__init__.py
@@ -170,61 +170,67 @@ def _handle_voice_enable(args: dict, **kw) -> str:
             "error": "Voice engines not available. Check voice_status for details.",
         })
 
-    if _pipeline and _pipeline.state.enabled:
-        return json.dumps({"ok": True, "message": "Voice mode already enabled."})
+    with _pipeline_lock:
+        if _pipeline and _pipeline.state.enabled:
+            return json.dumps({"ok": True, "message": "Voice mode already enabled."})
 
-    config = _get_config()
-    media_player = args.get("media_player_entity") or config["media_player_entity"] or None
+        config = _get_config()
+        media_player = args.get("media_player_entity") or config["media_player_entity"] or None
 
-    from plugins.voice_stack.pipeline import VoicePipeline
+        from plugins.voice_stack.pipeline import VoicePipeline
 
-    # Define the callback that sends user text to Hermes
-    # In production this is wired by the Hermes tool dispatch system.
-    # For now, the callback uses the HA tool bridge directly.
-    def _voice_callback(text: str) -> str:
-        """Called when STT produces text. This is where Hermes processes it."""
-        logger.info("Voice callback received: %s", text)
-        try:
-            from plugins.home_assistant.ha_assistant import (
-                search_entities,
-                call_service,
+        # Define the callback that sends user text to Hermes
+        # In production this is wired by the Hermes tool dispatch system.
+        # For now, the callback uses the HA tool bridge directly.
+        def _voice_callback(text: str) -> str:
+            """Called when STT produces text. This is where Hermes processes it."""
+            logger.info("Voice callback received: %s", text)
+            try:
+                from plugins.home_assistant.ha_assistant import (
+                    search_entities,
+                    call_service,
+                )
+            except ImportError:
+                return "The Home Assistant bridge is not available."
+            # For P1, delegate the actual LLM processing to the Hermes agent
+            # via a registered hook. The response here is a placeholder —
+            # the Hermes agent loop handles full NLU.
+            return (
+                f"I heard: {text}. "
+                "Voice processing is active — Hermes is listening."
             )
-        except ImportError:
-            return "The Home Assistant bridge is not available."
 
-        # For P1, delegate the actual LLM processing to the Hermes agent
-        # via a registered hook. The response here is a placeholder —
-        # the Hermes agent loop handles full NLU.
-        return (
-            f"I heard: {text}. "
-            "Voice processing is active — Hermes is listening."
+        _pipeline = VoicePipeline(
+            callback=_voice_callback,
+            wake_word_engine=_wake_word_engine,
+            stt_engine=_stt_engine,
+            tts_engine=_tts_engine,
+            media_player_entity=media_player,
+            max_record_duration=config["max_record_duration"],
+            silence_timeout=config["silence_timeout"],
+            confidence_threshold=config["confidence_threshold"],
         )
 
-    _pipeline = VoicePipeline(
-        callback=_voice_callback,
-        wake_word_engine=_wake_word_engine,
-        stt_engine=_stt_engine,
-        tts_engine=_tts_engine,
-        media_player_entity=media_player,
-        max_record_duration=config["max_record_duration"],
-        silence_timeout=config["silence_timeout"],
-        confidence_threshold=config["confidence_threshold"],
-    )
+        if not _pipeline.available:
+            _pipeline = None
+            return json.dumps({"ok": False, "error": "Engines not all available."})
 
-    if not _pipeline.available:
-        return json.dumps({"ok": False, "error": "Engines not all available."})
-
-    _pipeline.start()
+        started = _pipeline.start()
+        if not started:
+            _pipeline = None
+            return json.dumps({"ok": False, "error": "Voice pipeline failed to start."})
     return json.dumps({"ok": True, "message": "Voice mode enabled. Wake word active."})
+
 
 
 def _handle_voice_disable(args: dict, **kw) -> str:
     """Disable voice mode."""
     global _pipeline
-    if _pipeline:
-        _pipeline.stop()
-        _pipeline = None
-        return json.dumps({"ok": True, "message": "Voice mode disabled."})
+    with _pipeline_lock:
+        if _pipeline:
+            _pipeline.stop()
+            _pipeline = None
+            return json.dumps({"ok": True, "message": "Voice mode disabled."})
     return json.dumps({"ok": True, "message": "Voice mode was not active."})
 
 
@@ -261,24 +267,37 @@ def _handle_voice_listen(args: dict, **kw) -> str:
     """
     _ensure_voice_ready()
     if not _stt_engine or not _stt_engine.available():
-        return json.dumps({"ok": False, "error": "STT engine not available."})
+        return json.dumps({"ok": False, "error": "STT engine not available.", "error_category": "engine_unavailable"})
 
     config = _get_config()
-    duration = float(args.get("duration", config["max_record_duration"]))
+    try:
+        duration = float(args.get("duration", config["max_record_duration"]))
+    except (TypeError, ValueError):
+        return json.dumps({"ok": False, "error": "duration must be numeric", "error_category": "invalid_duration"})
+    if duration <= 0 or duration > 60:
+        return json.dumps({"ok": False, "error": "duration must be between 0 and 60 seconds", "error_category": "invalid_duration"})
     language = args.get("language", None)
 
     import tempfile
     from plugins.voice_stack.pipeline import record_audio
 
-    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False, dir=str(Path.home() / ".hermes" / "voice_cache")) as tmp:
+    cache_dir = Path.home() / ".hermes" / "voice_cache"
+    try:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        return json.dumps({"ok": False, "error": str(exc), "error_category": "cache_unavailable"})
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False, dir=str(cache_dir)) as tmp:
         audio_path = tmp.name
 
     try:
         recorded = record_audio(audio_path, duration=duration)
         if not recorded:
-            return json.dumps({"ok": False, "error": "No speech detected."})
-
-        result = _stt_engine.transcribe_with_confidence(audio_path, language=language)
+            return json.dumps({"ok": False, "error": "No speech detected.", "error_category": "no_speech"})
+        try:
+            result = _stt_engine.transcribe_with_confidence(audio_path, language=language)
+        except Exception as exc:
+            return json.dumps({"ok": False, "error": str(exc), "error_category": "transcription_failed"})
         return json.dumps({
             "ok": True,
             "text": result.get("text", ""),
@@ -286,7 +305,7 @@ def _handle_voice_listen(args: dict, **kw) -> str:
             "language": result.get("language", "unknown"),
         })
     except Exception as exc:
-        return json.dumps({"ok": False, "error": str(exc)})
+        return json.dumps({"ok": False, "error": str(exc), "error_category": "recording_failed"})
     finally:
         try:
             os.unlink(audio_path)

--- a/plugins/voice_stack/pipeline.py
+++ b/plugins/voice_stack/pipeline.py
@@ -27,6 +27,10 @@ from typing import Any, Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
+
+class VoiceRecordingError(RuntimeError):
+    """Raised when microphone capture fails before speech classification."""
+
 # ---------------------------------------------------------------------------
 # Audio recording helper
 # ---------------------------------------------------------------------------
@@ -48,9 +52,9 @@ def record_audio(
     import numpy as np
     try:
         import sounddevice as sd
-    except ImportError:
+    except ImportError as exc:
         logger.error("sounddevice not installed — cannot record audio")
-        return False
+        raise VoiceRecordingError("sounddevice not installed — cannot record audio") from exc
 
     try:
         # Record raw audio
@@ -98,7 +102,7 @@ def record_audio(
 
     except Exception as exc:
         logger.error("Audio recording failed: %s", exc)
-        return False
+        raise VoiceRecordingError(str(exc)) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -344,15 +348,23 @@ class VoicePipeline:
                     self._state.wake_word_detected = True
 
                 # 2. Record audio
-                with tempfile.NamedTemporaryFile(suffix=".wav", delete=False, dir=str(Path.home() / ".hermes" / "voice_cache")) as tmp:
+                cache_dir = Path.home() / ".hermes" / "voice_cache"
+                cache_dir.mkdir(parents=True, exist_ok=True)
+                with tempfile.NamedTemporaryFile(suffix=".wav", delete=False, dir=str(cache_dir)) as tmp:
                     audio_path = tmp.name
-                Path(audio_path).parent.mkdir(parents=True, exist_ok=True)
 
-                recorded = record_audio(
-                    audio_path,
-                    duration=self._max_record_duration,
-                    silence_timeout=self._silence_timeout,
-                )
+                try:
+                    recorded = record_audio(
+                        audio_path,
+                        duration=self._max_record_duration,
+                        silence_timeout=self._silence_timeout,
+                    )
+                except Exception:
+                    try:
+                        os.unlink(audio_path)
+                    except OSError:
+                        pass
+                    raise
                 if not recorded:
                     os.unlink(audio_path)
                     continue
@@ -388,16 +400,9 @@ class VoicePipeline:
                 if not response:
                     continue
 
-                # 5. TTS synthesis
-                audio_output = self._tts.synthesize(response)
-                if not audio_output:
+                # 5. TTS synthesis + playback
+                if not self._speak(response):
                     continue
-
-                # 6. Playback
-                if self._media_player_entity:
-                    play_audio_ha(audio_output, self._media_player_entity)
-                else:
-                    play_audio_local(audio_output)
 
                 self._state.total_interactions += 1
                 self._state.wake_word_detected = False
@@ -409,19 +414,24 @@ class VoicePipeline:
             finally:
                 self._state.listening = False
 
-    def _speak(self, text: str) -> None:
+    def _speak(self, text: str) -> bool:
         """Speak text through TTS + playback with retry fallback."""
         for attempt in (1, 2):
             try:
                 audio_path = self._tts.synthesize(text)
+                if not audio_path:
+                    raise RuntimeError("TTS engine returned no audio path")
                 if self._media_player_entity:
-                    play_audio_ha(audio_path, self._media_player_entity)
+                    played = play_audio_ha(audio_path, self._media_player_entity)
                 else:
-                    play_audio_local(audio_path)
-                return  # success
+                    played = play_audio_local(audio_path)
+                if not played:
+                    raise RuntimeError("Audio playback failed")
+                return True
             except Exception as exc:
                 logger.warning("TTS speak failed (attempt %d/2): %s", attempt, exc)
                 if attempt == 1:
                     time.sleep(0.5)  # brief backoff before retry
                 else:
                     logger.error("TTS speak failed after 2 attempts: %s", exc)
+        return False

--- a/plugins/voice_stack/ws_receiver.py
+++ b/plugins/voice_stack/ws_receiver.py
@@ -14,6 +14,7 @@ import json
 import logging
 import os
 import threading
+import time
 from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional
 
 try:
@@ -35,6 +36,54 @@ DEFAULT_WS_PATH = "/api/hermes/ws"
 
 _WS_SERVER: Optional["HermesHAWebSocketServer"] = None
 _WS_LOCK = threading.Lock()
+_START_TIME = time.monotonic()
+_MESSAGE_COUNTERS: dict[str, int] = {}
+_COUNTER_LOCK = threading.Lock()
+_VOICE_ACTION_RESERVED_KEYS = {"type", "action", "args"}
+
+
+def _record_message(msg_type: str) -> None:
+    """Track receiver message counts for health/status responses."""
+    key = msg_type or "<missing>"
+    with _COUNTER_LOCK:
+        _MESSAGE_COUNTERS[key] = _MESSAGE_COUNTERS.get(key, 0) + 1
+
+
+def _message_counters_snapshot() -> dict[str, int]:
+    with _COUNTER_LOCK:
+        return dict(_MESSAGE_COUNTERS)
+
+
+def receiver_status(server: Optional["HermesHAWebSocketServer"] = None) -> dict[str, Any]:
+    """Return process-local receiver health data safe for HA status probes."""
+    active_connections = 0
+    total_connections = 0
+    running = False
+    bound: dict[str, Any] = {}
+    target = server or _WS_SERVER
+    if target is not None:
+        active_connections = target.active_connections
+        total_connections = target.total_connections
+        running = target.running
+        bound = {"host": target.host, "port": target.port, "path": target.path}
+    return {
+        "ok": True,
+        "service": "hermes-ha-ws",
+        "running": running,
+        "uptime_seconds": round(time.monotonic() - _START_TIME, 1),
+        "auth_required": bool(_configured_token()),
+        "active_connections": active_connections,
+        "total_connections": total_connections,
+        "message_counters": _message_counters_snapshot(),
+        **bound,
+    }
+
+
+def _with_request_id(payload: dict[str, Any], response: dict[str, Any]) -> dict[str, Any]:
+    """Preserve caller request IDs for HA-side correlation."""
+    if "id" in payload and "id" not in response:
+        response = {**response, "id": payload["id"]}
+    return response
 
 
 def _json_loads_maybe(value: Any) -> dict[str, Any]:
@@ -84,8 +133,9 @@ def handle_voice_action(payload: dict[str, Any]) -> dict[str, Any]:
     """
     action = str(payload.get("action", "")).strip().lower()
     args = dict(payload.get("args") or {})
-    if payload.get("media_player_entity") and "media_player_entity" not in args:
-        args["media_player_entity"] = payload["media_player_entity"]
+    for key, value in payload.items():
+        if key not in _VOICE_ACTION_RESERVED_KEYS and key not in args:
+            args[key] = value
 
     from plugins.voice_stack import (
         _handle_voice_disable,
@@ -118,25 +168,29 @@ def handle_voice_action(payload: dict[str, Any]) -> dict[str, Any]:
 def handle_ha_ws_payload(payload: dict[str, Any]) -> dict[str, Any]:
     """Handle one JSON payload from Home Assistant."""
     msg_type = str(payload.get("type", "")).strip().lower()
+    _record_message(msg_type)
 
     if msg_type == "voice_action":
         result = handle_voice_action(payload)
-        return {"type": "voice_action_result", **result}
+        return _with_request_id(payload, {"type": "voice_action_result", **result})
 
     if msg_type == "state_changed":
         # P0 receiver behaviour: acknowledge state pushes so HA knows Hermes
         # accepted the event. Context ingestion can be layered on this later.
-        return {
+        return _with_request_id(payload, {
             "type": "ack",
             "ok": True,
             "received": "state_changed",
             "entity_id": payload.get("entity_id"),
-        }
+        })
 
-    if msg_type in {"ping", "status"}:
-        return {"type": "pong", "ok": True}
+    if msg_type == "ping":
+        return _with_request_id(payload, {"type": "pong", "ok": True})
 
-    return {"type": "error", "ok": False, "error": f"Unsupported message type: {msg_type or '<missing>'}"}
+    if msg_type == "status":
+        return _with_request_id(payload, {"type": "status", **receiver_status()})
+
+    return _with_request_id(payload, {"type": "error", "ok": False, "error": f"Unsupported message type: {msg_type or '<missing>'}"})
 
 
 class HermesHAWebSocketServer:
@@ -153,6 +207,28 @@ class HermesHAWebSocketServer:
         self._runner: Optional["aiohttp_web.AppRunner"] = None
         self._started = threading.Event()
         self._stopped = threading.Event()
+        self._active_connections = 0
+        self._total_connections = 0
+        self._connections_lock = threading.Lock()
+
+    @property
+    def active_connections(self) -> int:
+        with self._connections_lock:
+            return self._active_connections
+
+    @property
+    def total_connections(self) -> int:
+        with self._connections_lock:
+            return self._total_connections
+
+    def _connection_opened(self) -> None:
+        with self._connections_lock:
+            self._active_connections += 1
+            self._total_connections += 1
+
+    def _connection_closed(self) -> None:
+        with self._connections_lock:
+            self._active_connections = max(0, self._active_connections - 1)
 
     @property
     def running(self) -> bool:
@@ -221,7 +297,7 @@ class HermesHAWebSocketServer:
 
     async def _handle_health(self, request: "aiohttp_web.Request") -> "aiohttp_web.Response":
         assert web is not None
-        return web.json_response({"ok": True, "service": "hermes-ha-ws"})
+        return web.json_response({"type": "status", **receiver_status(self)})
 
     async def _handle_ws(self, request: "aiohttp_web.Request") -> "aiohttp_web.WebSocketResponse":
         assert web is not None
@@ -231,21 +307,25 @@ class HermesHAWebSocketServer:
 
         ws = web.WebSocketResponse(heartbeat=30)
         await ws.prepare(request)
+        self._connection_opened()
         await ws.send_json({"type": "hello", "ok": True, "service": "hermes-ha-ws"})
 
-        async for msg in ws:
-            if msg.type == WSMsgType.TEXT:
-                try:
-                    payload = json.loads(msg.data)
-                    if not isinstance(payload, dict):
-                        raise ValueError("payload must be a JSON object")
-                    response = handle_ha_ws_payload(payload)
-                except Exception as exc:
-                    response = {"type": "error", "ok": False, "error": str(exc)}
-                await ws.send_json(response)
-            elif msg.type == WSMsgType.ERROR:
-                logger.debug("HA WebSocket closed with error: %s", ws.exception())
-                break
+        try:
+            async for msg in ws:
+                if msg.type == WSMsgType.TEXT:
+                    try:
+                        payload = json.loads(msg.data)
+                        if not isinstance(payload, dict):
+                            raise ValueError("payload must be a JSON object")
+                        response = handle_ha_ws_payload(payload)
+                    except Exception as exc:
+                        response = {"type": "error", "ok": False, "error": str(exc)}
+                    await ws.send_json(response)
+                elif msg.type == WSMsgType.ERROR:
+                    logger.debug("HA WebSocket closed with error: %s", ws.exception())
+                    break
+        finally:
+            self._connection_closed()
         return ws
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -870,6 +870,47 @@ class TestVoiceWebSocketReceiver:
         assert result["ok"] is False
         assert "Unsupported voice action" in result["error"]
 
+    def test_response_preserves_request_id_and_status_payload(self, monkeypatch):
+        from plugins.voice_stack import ws_receiver
+
+        monkeypatch.setenv("HERMES_HA_WS_TOKEN", "secret")
+        result = ws_receiver.handle_ha_ws_payload({"id": "abc-123", "type": "status"})
+
+        assert result["id"] == "abc-123"
+        assert result["type"] == "status"
+        assert result["ok"] is True
+        assert result["auth_required"] is True
+        assert "uptime_seconds" in result
+        assert "active_connections" in result
+        assert result["message_counters"]["status"] >= 1
+
+    def test_voice_action_forwards_rich_context_args(self, monkeypatch):
+        from plugins.voice_stack import ws_receiver
+
+        seen = {}
+        monkeypatch.setattr(
+            "plugins.voice_stack._handle_voice_enable",
+            lambda args: seen.setdefault("args", args) or json.dumps({"ok": True}),
+        )
+
+        result = ws_receiver.handle_ha_ws_payload({
+            "id": 42,
+            "type": "voice_action",
+            "action": "enable",
+            "media_player_entity": "media_player.kitchen",
+            "entry_id": "entry-1",
+            "args": {"duration": 4},
+        })
+
+        assert result["id"] == 42
+        assert result["ok"] is True
+        assert seen["args"] == {
+            "id": 42,
+            "media_player_entity": "media_player.kitchen",
+            "entry_id": "entry-1",
+            "duration": 4,
+        }
+
     def test_auth_token_optional_and_enforced(self, monkeypatch):
         from plugins.voice_stack.ws_receiver import _auth_ok
 
@@ -882,6 +923,7 @@ class TestVoiceWebSocketReceiver:
         assert _auth_ok({}) is False
         assert _auth_ok({"Authorization": "Bearer secret"}) is True
         assert _auth_ok({"Authorization": "Bearer wrong"}) is False
+
 
 class TestHermesServices:
     """Custom component services.py tests."""
@@ -998,6 +1040,120 @@ class TestTTSRetry:
         # Second call succeeds
         assert tts.synthesize("hello") == "/tmp/test.mp3"
         assert call_count[0] == 2
+
+
+class TestVoiceLifecycleRobustness:
+    """Voice lifecycle locking and one-shot listening robustness."""
+
+    def test_voice_enable_disable_uses_single_pipeline_instance(self, monkeypatch):
+        import plugins.voice_stack as voice_stack
+
+        class FakeState:
+            enabled = False
+            def to_dict(self):
+                return {"enabled": self.enabled}
+
+        class FakePipeline:
+            instances = []
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                self.state = FakeState()
+                self.available = True
+                self.stopped = False
+                FakePipeline.instances.append(self)
+            def start(self):
+                self.state.enabled = True
+                return True
+            def stop(self):
+                self.stopped = True
+                self.state.enabled = False
+
+        monkeypatch.setattr("plugins.voice_stack.pipeline.VoicePipeline", FakePipeline)
+        monkeypatch.setattr(voice_stack, "_ensure_voice_ready", lambda: True)
+        monkeypatch.setattr(voice_stack, "_wake_word_engine", object())
+        monkeypatch.setattr(voice_stack, "_stt_engine", object())
+        monkeypatch.setattr(voice_stack, "_tts_engine", object())
+        voice_stack._voice_ready.set()
+        voice_stack._pipeline = None
+        try:
+            first = json.loads(voice_stack._handle_voice_enable({"media_player_entity": "media_player.kitchen"}))
+            second = json.loads(voice_stack._handle_voice_enable({"media_player_entity": "media_player.kitchen"}))
+            assert first["ok"] is True
+            assert second["ok"] is True
+            assert "already enabled" in second["message"]
+            assert len(FakePipeline.instances) == 1
+            assert FakePipeline.instances[0].kwargs["media_player_entity"] == "media_player.kitchen"
+
+            disabled = json.loads(voice_stack._handle_voice_disable({}))
+            assert disabled["ok"] is True
+            assert FakePipeline.instances[0].stopped is True
+            assert voice_stack._pipeline is None
+        finally:
+            voice_stack._pipeline = None
+            voice_stack._voice_ready.clear()
+
+    def test_voice_listen_creates_cache_dir_and_returns_no_speech_category(self, monkeypatch, tmp_path):
+        import plugins.voice_stack as voice_stack
+
+        class FakeSTT:
+            def available(self):
+                return True
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(voice_stack, "_ensure_voice_ready", lambda: True)
+        monkeypatch.setattr(voice_stack, "_stt_engine", FakeSTT())
+        monkeypatch.setattr("plugins.voice_stack.pipeline.record_audio", lambda path, duration: False)
+        voice_stack._voice_ready.set()
+        try:
+            result = json.loads(voice_stack._handle_voice_listen({"duration": 1}))
+        finally:
+            voice_stack._voice_ready.clear()
+
+        assert result["ok"] is False
+        assert result["error_category"] == "no_speech"
+        assert (tmp_path / ".hermes" / "voice_cache").is_dir()
+
+    def test_voice_listen_reports_recording_failure_category(self, monkeypatch, tmp_path):
+        import plugins.voice_stack as voice_stack
+        from plugins.voice_stack.pipeline import VoiceRecordingError
+
+        class FakeSTT:
+            def available(self):
+                return True
+
+        def boom(path, duration):
+            raise VoiceRecordingError("microphone unavailable")
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(voice_stack, "_ensure_voice_ready", lambda: True)
+        monkeypatch.setattr(voice_stack, "_stt_engine", FakeSTT())
+        monkeypatch.setattr("plugins.voice_stack.pipeline.record_audio", boom)
+        voice_stack._voice_ready.set()
+        try:
+            result = json.loads(voice_stack._handle_voice_listen({"duration": 1}))
+        finally:
+            voice_stack._voice_ready.clear()
+
+        assert result["ok"] is False
+        assert result["error_category"] == "recording_failed"
+        assert "microphone unavailable" in result["error"]
+
+    def test_voice_listen_rejects_invalid_duration(self, monkeypatch):
+        import plugins.voice_stack as voice_stack
+
+        class FakeSTT:
+            def available(self):
+                return True
+
+        monkeypatch.setattr(voice_stack, "_ensure_voice_ready", lambda: True)
+        monkeypatch.setattr(voice_stack, "_stt_engine", FakeSTT())
+        voice_stack._voice_ready.set()
+        try:
+            result = json.loads(voice_stack._handle_voice_listen({"duration": "banana"}))
+        finally:
+            voice_stack._voice_ready.clear()
+
+        assert result == {"ok": False, "error": "duration must be numeric", "error_category": "invalid_duration"}
 
 
 class TestHomescriptSkill:


### PR DESCRIPTION
## Summary
- Preserve WebSocket request IDs and expose receiver status/health telemetry, including uptime, auth mode, active/total connections, and message counters.
- Forward richer HA voice-action context into voice-stack handlers while preserving explicit `args` precedence.
- Reuse the voice pipeline lock for enable/disable lifecycle paths and cleanly handle failed starts.
- Create voice cache directories before temporary recordings and return stable `voice_listen` error categories.
- Raise `VoiceRecordingError` for microphone/import failures so recording failures are not misreported as silence.
- Document the HA→Hermes WebSocket wire protocol and update receiver docs.

## Verification
- [x] `python -m compileall -q custom_components plugins tests scripts`
- [x] `python -m pytest -q` (124 passed)
- [x] `python -m build --sdist --wheel`
- [x] `python scripts/check_release_integrity.py`
- [x] `git diff --check`
- [x] Multi-model review: GPT reviewer found a recording-failure categorisation blocker; fixed with `VoiceRecordingError` and regression coverage. Re-review returned READY. Aeon-fast review listed lifecycle/cache/tempfile/context risks; verified source uses context-managed lock, `mkdir(..., exist_ok=True)`, `delete=False`, and explicit `args` precedence.

Closes #6
