### PR TITLE
chore: prepare v0.0.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `hermes-voice-ha-integration`.
 
 ## [Unreleased]
 
+## [0.0.6] — 2026-05-25
+
 ### Added
 - Added structured service responses and runtime schemas for `hermes.hermes_command` and `hermes.voice_settings`.
 - Added tests for Home Assistant service response handling, voice settings queries, option wiring, and entry-scoped sensor IDs.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository is a bundle of three pieces:
 
 The Python wheel is intentionally plugin-focused. Use the GitHub tag or source distribution for the full HACS/custom-component/add-on bundle.
 
-> **Release:** `v0.0.5` — ships runtime Home Assistant translations so the setup form explains exactly what the Hermes URL and token fields mean.
+> **Release:** `v0.0.6` — ships runtime Home Assistant translations so the setup form explains exactly what the Hermes URL and token fields mean.
 
 ---
 
@@ -507,7 +507,7 @@ High-level flow:
 4. Start the add-on.
 5. Open the add-on logs and confirm Hermes starts cleanly.
 
-The add-on is intentionally marked `boot: manual` in `v0.0.5`. Start it manually first, verify logs, then decide whether to change boot behaviour later.
+The add-on is intentionally marked `boot: manual` in `v0.0.6`. Start it manually first, verify logs, then decide whether to change boot behaviour later.
 
 ---
 
@@ -662,7 +662,7 @@ Check:
 
 ---
 
-## Known limitations in `v0.0.5`
+## Known limitations in `v0.0.6`
 
 - The voice stack is usable as engine wrappers and Hermes tools, but room-grade voice satellite UX still needs more work.
 - TTS audio delivery to HA media players may need an HTTP/media bridge depending on deployment topology.

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,5 +1,5 @@
 name: "Hermes Voice Assistant"
-version: "0.0.5"
+version: "0.0.6"
 slug: "hermes_voice"
 description: "Voice assistant bridge for Home Assistant — wake word → STT → Hermes LLM → TTS → media_player. Can run local-first with local engines."
 url: "https://github.com/rusty4444/hermes-voice-ha-integration"

--- a/custom_components/hermes/manifest.json
+++ b/custom_components/hermes/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/rusty4444/hermes-voice-ha-integration/issues",
   "requirements": [],
-  "version": "0.0.5"
+  "version": "0.0.6"
 }

--- a/plugins/home_assistant/plugin.yaml
+++ b/plugins/home_assistant/plugin.yaml
@@ -1,5 +1,5 @@
 name: home_assistant
-version: 0.0.5
+version: 0.0.6
 description: "Home Assistant plugin for Hermes Agent — bidirectional entity sync, service routing, entity discovery, and compound smart-home tools."
 author: "Sam Russell <sam.russell@samprim.net>"
 hooks:

--- a/plugins/voice_stack/plugin.yaml
+++ b/plugins/voice_stack/plugin.yaml
@@ -1,5 +1,5 @@
 name: voice_stack
-version: 0.0.5
+version: 0.0.6
 description: "Local voice pipeline: Wake Word → STT → Hermes LLM → TTS → HA media_player."
 author: "Sam Russell <sam.russell@samprim.net>"
 hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermes-voice-ha-integration"
-version = "0.0.5"
+version = "0.0.6"
 description = "Home Assistant voice stack integration for Hermes Agent"
 authors = [{name = "Sam Russell", email = "sam.russell@samprim.net"}]
 license = "MIT"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -308,7 +308,7 @@ class TestPluginRegistration:
         with open(yaml_path) as f:
             data = yaml.safe_load(f)
         assert data["name"] == "home_assistant"
-        assert data["version"] == "0.0.5"
+        assert data["version"] == "0.0.6"
         assert "on_session_start" in data["hooks"]
 
     def test_voice_stack_plugin_yaml_valid(self):
@@ -318,7 +318,7 @@ class TestPluginRegistration:
         with open(yaml_path) as f:
             data = yaml.safe_load(f)
         assert data["name"] == "voice_stack"
-        assert data["version"] == "0.0.5"
+        assert data["version"] == "0.0.6"
 
 
 # ---------------------------------------------------------------------------
@@ -558,7 +558,7 @@ class TestObservability:
         assert data["domain"] == "hermes"
         assert data["config_flow"] is True
         assert "iot_class" in data
-        assert data["version"] == "0.0.5"
+        assert data["version"] == "0.0.6"
 
     def test_config_flow_translations_are_packaged_for_ha_ui(self):
         """HA must ship runtime translations, not only source strings.json."""
@@ -607,7 +607,7 @@ class TestAddonStructure:
         with open(config_path) as f:
             data = yaml.safe_load(f)
         assert data["name"] == "Hermes Voice Assistant"
-        assert data["version"] == "0.0.5"
+        assert data["version"] == "0.0.6"
         assert data["slug"] == "hermes_voice"
         assert "arch" in data
         assert "amd64" in data["arch"] or "aarch64" in data["arch"]
@@ -826,7 +826,7 @@ class TestVoicePluginInit:
         assert "HERMES_WAKE_WORD_ENGINE" in data["config"]
         assert "HERMES_HA_WS_PORT" in data["config"]
         assert "HERMES_HA_WS_TOKEN" in data["config"]
-        assert data["version"] == "0.0.5"
+        assert data["version"] == "0.0.6"
 
 
 
@@ -1213,7 +1213,7 @@ class TestCHANGELOG:
     def test_changelog_has_version_entries(self):
         cl = Path(__file__).parent.parent / "CHANGELOG.md"
         content = cl.read_text()
-        assert "## [0.0.5]" in content
+        assert "## [0.0.6]" in content
         assert "## [0.0.1]" in content
         assert "## [0.2.0]" in content or "## [0.1.0]" in content
 


### PR DESCRIPTION
## Summary
- Bump package, HA manifest, add-on, and plugin metadata to `0.0.6`.
- Move accumulated robustness work into the `0.0.6` changelog section.
- Update README release reference.

## Verification
- [x] compileall + pytest (124 passed)
- [x] `python -m build --sdist --wheel`
- [x] `scripts/check_release_integrity.py --tag v0.0.6`
- [x] `git diff --check`

Closes #10