### PR TITLE
fix(plugins): add explicit __path__ resolution for user plugin discovery

### DIFF
--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,1 +1,27 @@
-# Hermes plugin packages
+"""Hermes plugin packages.
+
+Sub-packages (voice_stack, home_assistant, etc.) are discovered from all
+plugin installation locations to support both pip-installed and
+user-installed (``~/.hermes/plugins/``) workflows.
+
+Without explicit ``__path__`` resolution, Python only looks in the parent
+directory of the first ``plugins`` package it finds on ``sys.path``.  When
+``hermes-agent``'s own ``plugins/`` package shadows this one, sub-packages
+become unreachable.  Including ``~/.hermes/plugins/`` in ``__path__``
+ensures user-installed plugins are always importable.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+_this_dir = Path(__file__).parent.resolve()
+_user_plugins = Path.home() / ".hermes" / "plugins"
+
+# Start with the current directory -- this always contains our sub-packages.
+__path__ = [str(_this_dir)]
+
+# If the user plugins directory exists and is different, include it so
+# cross-package imports (e.g. voice_stack importing from home_assistant)
+# work when plugins are installed there.
+if _user_plugins.resolve() != _this_dir and _user_plugins.is_dir():
+    __path__.append(str(_user_plugins.resolve()))


### PR DESCRIPTION
## Summary

Fixes #16

The `plugins/__init__.py` stub was a bare comment, relying entirely on Python's default package resolution. When a different `plugins` package (e.g. from `hermes-agent`) is found first on `sys.path`, sub-packages like `voice_stack` and `home_assistant` in this package become unreachable, causing:

```
Failed to load plugin 'voice_stack': No module named 'plugins.voice_stack'
```

## Changes

Replaced the bare comment with a proper docstring and dynamic `__path__` resolution that:
1. **Always includes the current directory** so pip-installed packages work as expected
2. **Dynamically adds `~/.hermes/plugins/`** to `__path__` when it exists and differs from the current directory — this makes user-installed plugins discoverable even when the Hermes Agent's `plugins/` package takes precedence on `sys.path`

## What this fixes

- `import plugins.voice_stack` now works when plugins are installed to `~/.hermes/plugins/`
- Cross-package imports (e.g. `voice_stack` importing from `home_assistant`) resolve correctly
- Both pip-installed and user-installed (`~/.hermes/plugins/`) workflows are supported

## Additional note

The Hermes Agent's own `plugins/__init__.py` (at `hermes-agent/plugins/__init__.py`) is also a bare stub. For a complete fix, that file should also include `~/.hermes/plugins/` in its `__path__`. This PR fixes the plugin-side; the Hermes Agent side may need a separate change.