### PR TITLE
fix: use _config_entry to avoid OptionsFlow property crash

### DIFF
--- a/custom_components/hermes/config_flow.py
+++ b/custom_components/hermes/config_flow.py
@@ -105,12 +105,12 @@ class HermesOptionsFlow(OptionsFlow):
     """Multi-step options flow for Hermes."""
 
     def __init__(self, config_entry: ConfigEntry) -> None:
-        self.config_entry = config_entry
+        self._config_entry = config_entry
         self._pending: dict | None = None
 
     async def async_step_init(self, user_input: dict | None = None) -> FlowResult:
         """Step 1 — entity allow-list and SSL verification."""
-        current = dict(self.config_entry.options or {})
+        current = dict(self._config_entry.options or {})
 
         if user_input is not None:
             self._pending = {
@@ -144,7 +144,7 @@ class HermesOptionsFlow(OptionsFlow):
 
     async def async_step_voice(self, user_input: dict | None = None) -> FlowResult:
         """Step 2 — voice pipeline configuration."""
-        current = dict(self.config_entry.options or {})
+        current = dict(self._config_entry.options or {})
         if self._pending:
             current.update(self._pending)
 


### PR DESCRIPTION
Home Assistant 2025.x made the `config_entry` property on `OptionsFlow` read-only (framework-managed). Assigning to `self.config_entry` in `__init__` raises:\n\n\n\n**What changed:**\n- Renamed `self.config_entry` to `self._config_entry` in `HermesOptionsFlow.__init__`\n- Updated both references (`async_step_init` and `async_step_voice`) to use `self._config_entry`\n\nThis resolves the crash described in issue #21.