### PR TITLE
fix: load Hermes plugins from user namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `hermes-voice-ha-integration`.
 
 ## [Unreleased]
 
+## [0.0.7] — 2026-05-31
+
 ### Added
 - Added structured service responses and runtime schemas for `hermes.hermes_command` and `hermes.voice_settings`.
 - Added tests for Home Assistant service response handling, voice settings queries, option wiring, and entry-scoped sensor IDs.
@@ -11,6 +13,8 @@ All notable changes to `hermes-voice-ha-integration`.
 - Added voice lifecycle tests covering richer HA action context, pipeline locking, cache directory creation, and categorized one-shot listen failures.
 
 ### Fixed
+- Fixed Hermes user-plugin imports by replacing bundled `plugins.*` absolute imports with package-relative imports so `home_assistant` and `voice_stack` load correctly from Hermes plugin namespaces.
+- Clarified README plugin installation paths for issue #23.
 - Passed configured TTS/STT/wake-word/media-player options into the Home Assistant `HermesBridge` instead of always using bridge defaults.
 - Preserved page-1 options-flow values when saving page-2 voice settings.
 - Normalized wake-word options to a list consistently before storing or forwarding them.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repository is a bundle of three pieces:
 
 The Python wheel is intentionally plugin-focused. Use the GitHub tag or source distribution for the full HACS/custom-component/add-on bundle.
 
-> **Release:** `v0.0.5` — ships runtime Home Assistant translations so the setup form explains exactly what the Hermes URL and token fields mean.
+> **Release:** `v0.0.7` — fixes user-plugin import loading, README install paths, and Home Assistant voice-bridge setup guidance.
 
 ---
 
@@ -534,7 +534,7 @@ High-level flow:
 4. Start the add-on.
 5. Open the add-on logs and confirm Hermes starts cleanly.
 
-The add-on is intentionally marked `boot: manual` in `v0.0.5`. Start it manually first, verify logs, then decide whether to change boot behaviour later.
+The add-on is intentionally marked `boot: manual` in `v0.0.7`. Start it manually first, verify logs, then decide whether to change boot behaviour later.
 
 ---
 
@@ -689,7 +689,7 @@ Check:
 
 ---
 
-## Known limitations in `v0.0.5`
+## Known limitations in `v0.0.7`
 
 - The voice stack is usable as engine wrappers and Hermes tools, but room-grade voice satellite UX still needs more work.
 - TTS audio delivery to HA media players may need an HTTP/media bridge depending on deployment topology.

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,5 +1,5 @@
 name: "Hermes Voice Assistant"
-version: "0.0.5"
+version: "0.0.7"
 slug: "hermes_voice"
 description: "Voice assistant bridge for Home Assistant — wake word → STT → Hermes LLM → TTS → media_player. Can run local-first with local engines."
 url: "https://github.com/rusty4444/hermes-voice-ha-integration"

--- a/custom_components/hermes/manifest.json
+++ b/custom_components/hermes/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/rusty4444/hermes-voice-ha-integration/issues",
   "requirements": [],
-  "version": "0.0.5"
+  "version": "0.0.7"
 }

--- a/plugins/home_assistant/__init__.py
+++ b/plugins/home_assistant/__init__.py
@@ -19,7 +19,7 @@ import re
 import time as _time
 from typing import Any, Dict, Optional, Tuple
 
-from plugins.home_assistant.ha_assistant import (
+from .ha_assistant import (
     call_service,
     get_entity_state,
     invalidate_cache,
@@ -28,7 +28,7 @@ from plugins.home_assistant.ha_assistant import (
     refresh_entity_cache,
     search_entities,
 )
-from plugins.home_assistant.compound import (
+from .compound import (
     BULK_CONTROL_SCHEMA,
     CONTROL_LIGHT_AND_SET_SCENE_SCHEMA,
     TURN_OFF_ALL_EXCEPT_SCHEMA,
@@ -36,7 +36,7 @@ from plugins.home_assistant.compound import (
     _handle_control_light_and_set_scene,
     _handle_turn_off_all_except,
 )
-from plugins.home_assistant.security import (
+from .security import (
     is_entity_blocked,
     is_service_allowed,
     log_call,
@@ -334,7 +334,7 @@ def _on_session_start(**kwargs) -> None:
             url, token = _get_ha_creds()
             thread = _WS_LISTENER_THREAD
             if thread is None or not thread.is_alive():
-                from plugins.home_assistant.event_watcher import start_ws_listener
+                from .event_watcher import start_ws_listener
                 if url.startswith("https://"):
                     ws_url = "wss://" + url[len("https://"):]
                 elif url.startswith("http://"):
@@ -350,7 +350,7 @@ def _on_session_start(**kwargs) -> None:
                 logger.info("HA WS event listener skipped (no aiohttp available)")
 
             # --- P3: Scene/Script auto-discovery ---
-            from plugins.home_assistant.discovery import discover_scenes_scripts
+            from .discovery import discover_scenes_scripts
             discovered = discover_scenes_scripts()
             logger.info(
                 "Auto-discovered %d scenes + %d scripts from HA",
@@ -360,7 +360,7 @@ def _on_session_start(**kwargs) -> None:
 
             # --- P3: Set initial status sensor values ---
             try:
-                from plugins.home_assistant.status_sensors import get_status_sensors
+                from .status_sensors import get_status_sensors
                 sensors = get_status_sensors()
                 sensors.start_time = _time.monotonic()
                 sensors.gateway_connected = True

--- a/plugins/home_assistant/compound.py
+++ b/plugins/home_assistant/compound.py
@@ -15,7 +15,7 @@ import json
 import logging
 from typing import Any, Dict, List, Optional
 
-from plugins.home_assistant.ha_assistant import call_service, search_entities
+from .ha_assistant import call_service, search_entities
 
 logger = logging.getLogger(__name__)
 
@@ -260,7 +260,7 @@ def _handle_bulk_control(args: dict, **kw) -> str:
     futures: dict = {}
 
     # We reuse the existing thread pool from ha_assistant.py
-    from plugins.home_assistant.ha_assistant import call_service
+    from .ha_assistant import call_service
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=min(len(operations), 10)) as executor:
         for i, op in enumerate(operations):

--- a/plugins/home_assistant/discovery.py
+++ b/plugins/home_assistant/discovery.py
@@ -20,7 +20,7 @@ def discover_scenes_scripts() -> Dict[str, Any]:
     Returns: {"scenes": [...], "scripts": [...], "total_scenes": N, "total_scripts": N}
     """
     try:
-        from plugins.home_assistant.ha_assistant import search_entities
+        from .ha_assistant import search_entities
 
         scenes = search_entities(domain="scene")
         scripts = search_entities(domain="script")
@@ -93,7 +93,7 @@ def make_scene_handler(entity_id: str) -> Callable[..., str]:
     """Return a handler function that activates the given scene."""
 
     def _handler(args: dict, **kw) -> str:
-        from plugins.home_assistant.ha_assistant import call_service
+        from .ha_assistant import call_service
         result = call_service("scene", "turn_on", entity_id=entity_id)
         if "error" in result:
             return json.dumps({"error": result["error"]})
@@ -106,7 +106,7 @@ def make_script_handler(entity_id: str) -> Callable[..., str]:
     """Return a handler function that runs the given script."""
 
     def _handler(args: dict, **kw) -> str:
-        from plugins.home_assistant.ha_assistant import call_service
+        from .ha_assistant import call_service
         result = call_service("script", "turn_on", entity_id=entity_id)
         if "error" in result:
             return json.dumps({"error": result["error"]})

--- a/plugins/home_assistant/ha_assistant.py
+++ b/plugins/home_assistant/ha_assistant.py
@@ -27,7 +27,7 @@ def _ensure_security_imported():
     global _security_log_call, _security_is_entity_blocked, _security_is_service_allowed
     if _security_log_call is None:
         try:
-            from plugins.home_assistant.security import (
+            from .security import (
                 is_entity_blocked as _is_blocked,
                 is_service_allowed as _is_allowed,
                 log_call as _log,

--- a/plugins/home_assistant/plugin.yaml
+++ b/plugins/home_assistant/plugin.yaml
@@ -1,5 +1,5 @@
 name: home_assistant
-version: 0.0.5
+version: 0.0.7
 description: "Home Assistant plugin for Hermes Agent — bidirectional entity sync, service routing, entity discovery, and compound smart-home tools."
 author: "Sam Russell <sam.russell@samprim.net>"
 hooks:

--- a/plugins/voice_stack/__init__.py
+++ b/plugins/voice_stack/__init__.py
@@ -62,7 +62,7 @@ def _init_engines() -> bool:
     config = _get_config()
 
     # TTS
-    from plugins.voice_stack.engines.tts import create_tts_engine
+    from .engines.tts import create_tts_engine
     try:
         _tts_engine = create_tts_engine(
             engine_type=config["tts"]["engine"],
@@ -73,7 +73,7 @@ def _init_engines() -> bool:
         _tts_engine = None
 
     # STT
-    from plugins.voice_stack.engines.stt import create_stt_engine
+    from .engines.stt import create_stt_engine
     try:
         _stt_engine = create_stt_engine(
             engine_type=config["stt"]["engine"],
@@ -84,7 +84,7 @@ def _init_engines() -> bool:
         _stt_engine = None
 
     # Wake Word (optional — voice mode works without it via voice_listen)
-    from plugins.voice_stack.engines.wake_word import create_wake_word_engine
+    from .engines.wake_word import create_wake_word_engine
     try:
         _wake_word_engine = create_wake_word_engine(
             engine_type=config["wake_word"]["engine"],
@@ -177,7 +177,7 @@ def _handle_voice_enable(args: dict, **kw) -> str:
         config = _get_config()
         media_player = args.get("media_player_entity") or config["media_player_entity"] or None
 
-        from plugins.voice_stack.pipeline import VoicePipeline
+        from .pipeline import VoicePipeline
 
         # Define the callback that sends user text to Hermes
         # In production this is wired by the Hermes tool dispatch system.
@@ -186,7 +186,7 @@ def _handle_voice_enable(args: dict, **kw) -> str:
             """Called when STT produces text. This is where Hermes processes it."""
             logger.info("Voice callback received: %s", text)
             try:
-                from plugins.home_assistant.ha_assistant import (
+                from ..home_assistant.ha_assistant import (
                     search_entities,
                     call_service,
                 )
@@ -245,7 +245,7 @@ def _handle_voice_speak(args: dict, **kw) -> str:
         return json.dumps({"ok": False, "error": "No text provided."})
 
     try:
-        from plugins.voice_stack.pipeline import play_audio_local, play_audio_ha
+        from .pipeline import play_audio_local, play_audio_ha
 
         audio_path = _tts_engine.synthesize(text)
         media_player = args.get("media_player_entity") or _get_config().get("media_player_entity", "")
@@ -279,7 +279,7 @@ def _handle_voice_listen(args: dict, **kw) -> str:
     language = args.get("language", None)
 
     import tempfile
-    from plugins.voice_stack.pipeline import record_audio
+    from .pipeline import record_audio
 
     cache_dir = Path.home() / ".hermes" / "voice_cache"
     try:
@@ -315,12 +315,12 @@ def _handle_voice_listen(args: dict, **kw) -> str:
 
 def _handle_voice_prompt(args: dict, **kw) -> str:
     """Return the voice-optimised system prompt with current HA context."""
-    from plugins.voice_stack.pipeline import build_voice_system_prompt
+    from .pipeline import build_voice_system_prompt
 
     areas = None
     entities = None
     try:
-        from plugins.home_assistant.ha_assistant import search_entities
+        from ..home_assistant.ha_assistant import search_entities
     except ImportError:
         pass
     else:
@@ -459,7 +459,7 @@ def register(ctx) -> None:
     # port is already occupied or aiohttp is unavailable, the warning is logged
     # and normal tool registration still succeeds.
     try:
-        from plugins.voice_stack.ws_receiver import start_ws_receiver
+        from .ws_receiver import start_ws_receiver
         start_ws_receiver()
     except Exception as exc:
         logger.warning("Hermes HA WebSocket receiver did not start: %s", exc)

--- a/plugins/voice_stack/audio.py
+++ b/plugins/voice_stack/audio.py
@@ -6,5 +6,5 @@ This module is a backwards-compatibility shim. New code uses:
 - plugins.voice_stack.pipeline.play_audio_ha()
 """
 
-from plugins.voice_stack.pipeline import play_audio_local as play_audio_file  # noqa: F401
-from plugins.voice_stack.pipeline import record_audio  # noqa: F401
+from .pipeline import play_audio_local as play_audio_file  # noqa: F401
+from .pipeline import record_audio  # noqa: F401

--- a/plugins/voice_stack/pipeline.py
+++ b/plugins/voice_stack/pipeline.py
@@ -143,7 +143,7 @@ def play_audio_ha(audio_path: str, media_player_entity: str) -> bool:
     """
     # Import the HA bridge to call services
     try:
-        from plugins.home_assistant.ha_assistant import call_service
+        from ..home_assistant.ha_assistant import call_service
     except ImportError:
         logger.error("HA bridge not available — cannot use media_player playback")
         return False

--- a/plugins/voice_stack/plugin.yaml
+++ b/plugins/voice_stack/plugin.yaml
@@ -1,5 +1,5 @@
 name: voice_stack
-version: 0.0.5
+version: 0.0.7
 description: "Local voice pipeline: Wake Word → STT → Hermes LLM → TTS → HA media_player."
 author: "Sam Russell <sam.russell@samprim.net>"
 hooks:

--- a/plugins/voice_stack/ws_receiver.py
+++ b/plugins/voice_stack/ws_receiver.py
@@ -137,7 +137,7 @@ def handle_voice_action(payload: dict[str, Any]) -> dict[str, Any]:
         if key not in _VOICE_ACTION_RESERVED_KEYS and key not in args:
             args[key] = value
 
-    from plugins.voice_stack import (
+    from . import (
         _handle_voice_disable,
         _handle_voice_enable,
         _handle_voice_status,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermes-voice-ha-integration"
-version = "0.0.5"
+version = "0.0.7"
 description = "Home Assistant voice stack integration for Hermes Agent"
 authors = [{name = "Sam Russell", email = "sam.russell@samprim.net"}]
 license = "MIT"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -308,7 +308,7 @@ class TestPluginRegistration:
         with open(yaml_path) as f:
             data = yaml.safe_load(f)
         assert data["name"] == "home_assistant"
-        assert data["version"] == "0.0.5"
+        assert data["version"] == "0.0.7"
         assert "on_session_start" in data["hooks"]
 
     def test_voice_stack_plugin_yaml_valid(self):
@@ -318,7 +318,7 @@ class TestPluginRegistration:
         with open(yaml_path) as f:
             data = yaml.safe_load(f)
         assert data["name"] == "voice_stack"
-        assert data["version"] == "0.0.5"
+        assert data["version"] == "0.0.7"
 
 
 # ---------------------------------------------------------------------------
@@ -558,7 +558,7 @@ class TestObservability:
         assert data["domain"] == "hermes"
         assert data["config_flow"] is True
         assert "iot_class" in data
-        assert data["version"] == "0.0.5"
+        assert data["version"] == "0.0.7"
 
     def test_config_flow_translations_are_packaged_for_ha_ui(self):
         """HA must ship runtime translations, not only source strings.json."""
@@ -607,7 +607,7 @@ class TestAddonStructure:
         with open(config_path) as f:
             data = yaml.safe_load(f)
         assert data["name"] == "Hermes Voice Assistant"
-        assert data["version"] == "0.0.5"
+        assert data["version"] == "0.0.7"
         assert data["slug"] == "hermes_voice"
         assert "arch" in data
         assert "amd64" in data["arch"] or "aarch64" in data["arch"]
@@ -826,7 +826,7 @@ class TestVoicePluginInit:
         assert "HERMES_WAKE_WORD_ENGINE" in data["config"]
         assert "HERMES_HA_WS_PORT" in data["config"]
         assert "HERMES_HA_WS_TOKEN" in data["config"]
-        assert data["version"] == "0.0.5"
+        assert data["version"] == "0.0.7"
 
 
 
@@ -1213,8 +1213,38 @@ class TestCHANGELOG:
     def test_changelog_has_version_entries(self):
         cl = Path(__file__).parent.parent / "CHANGELOG.md"
         content = cl.read_text()
-        assert "## [0.0.5]" in content
+        assert "## [0.0.7]" in content
         assert "## [0.0.1]" in content
         assert "## [0.2.0]" in content or "## [0.1.0]" in content
 
 
+
+
+def test_plugins_import_from_user_plugin_namespace(monkeypatch, tmp_path):
+    """User-installed plugins load under Hermes' dynamic plugin namespace.
+
+    Absolute imports like ``from plugins.voice_stack...`` fail there because
+    the user plugin namespace is ``hermes_plugins``. Package-relative imports
+    must keep both sibling plugins importable without touching the local Hermes
+    source tree.
+    """
+    import importlib
+    import shutil
+    import sys
+    import types
+
+    root = Path(__file__).resolve().parents[1]
+    namespace_dir = tmp_path / "hermes_plugins"
+    namespace_dir.mkdir()
+    shutil.copytree(root / "plugins" / "home_assistant", namespace_dir / "home_assistant")
+    shutil.copytree(root / "plugins" / "voice_stack", namespace_dir / "voice_stack")
+
+    namespace = types.ModuleType("hermes_plugins")
+    namespace.__path__ = [str(namespace_dir)]  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "hermes_plugins", namespace)
+
+    home_assistant = importlib.import_module("hermes_plugins.home_assistant")
+    voice_stack = importlib.import_module("hermes_plugins.voice_stack")
+
+    assert hasattr(home_assistant, "register")
+    assert hasattr(voice_stack, "register")


### PR DESCRIPTION
## Summary
- Replace absolute `plugins.*` imports with package-relative imports so the Hermes `home_assistant` and `voice_stack` plugins load under Hermes' dynamic user-plugin namespace.
- Add a regression test that imports both plugins from a simulated `hermes_plugins` namespace without touching the local Hermes source tree.
- Bump release metadata and docs to `0.0.7`.

## Test Plan
- `python scripts/check_release_integrity.py --tag v0.0.7 --no-artifacts`
- `python -m pytest -q`

Fixes #23.
