### PR TITLE
Fix add-on Hermes home and cache path

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,9 @@ ws://<hermes-host>:7860/api/hermes/ws
 
 Home Assistant connects to this endpoint through the **Hermes URL** you enter below. If `HERMES_HA_WS_TOKEN`, `API_SERVER_KEY`, or `HERMES_API_KEY` is set, the HA custom integration token must match it.
 
+When running the Home Assistant add-on, expose/map TCP port `7860` so Home Assistant can reach the HA-facing receiver. The bundled add-on config maps `7860/tcp` by default.
+
+The add-on also sets `HOME`, `HERMES_HOME`, and `HERMES_VOICE_CACHE` to `/data/hermes` so voice engines that call `Path.home()` write their cache under `/data/hermes/voice_cache` instead of `/root/.hermes/voice_cache`.
 
 ---
 
@@ -309,6 +312,8 @@ Home Assistant  →  http://<hermes-host>:7860  →  /api/hermes/ws
 ```
 
 Do **not** enter `http://homeassistant.local:8123` in the Hermes URL field. That URL is only used by Hermes itself when Hermes talks back to Home Assistant via `HASS_URL`.
+
+This integration currently exposes Hermes services, status sensors, and the HA-to-Hermes WebSocket bridge. It does **not** yet register a Home Assistant Assist/conversation agent, so it will not appear in the **Preferred conversation agent** selector until a dedicated conversation platform is added.
 
 5. Submit.
 
@@ -678,6 +683,22 @@ HASS_URL=http://192.168.1.50:8123
 - Confirm `HERMES_MEDIA_PLAYER` is a real `media_player.*` entity.
 - Confirm the player supports `play_media`.
 - If running Hermes outside HA, ensure HA can access generated audio. This may need an HTTP-accessible media bridge.
+
+### Permission denied for `/root/.hermes/voice_cache` in the add-on
+
+Update to an add-on build that sets `HOME=/data/hermes`. The add-on should log the Hermes home as `/data/hermes`, and the cache directory should be `/data/hermes/voice_cache`.
+
+If you are running a custom container, set these environment variables explicitly:
+
+```bash
+HOME=/data/hermes
+HERMES_HOME=/data/hermes
+HERMES_VOICE_CACHE=/data/hermes/voice_cache
+```
+
+### Port `7860` is already in use
+
+Only one process in the container or host can bind `0.0.0.0:7860`. If the HA WebSocket receiver logs `address already in use`, check whether another Hermes process or an old container is already listening on that port, then stop the duplicate process or move one receiver to a different `HERMES_HA_WS_PORT` and update the Hermes URL in the HA integration accordingly.
 
 ### Service call denied
 

--- a/addon/Dockerfile
+++ b/addon/Dockerfile
@@ -67,8 +67,10 @@ RUN cp -R /opt/hermes-voice-ha-integration/plugins/home_assistant /opt/hermes-ag
 COPY run.sh /opt/run.sh
 RUN chmod +x /opt/run.sh
 
-# Hermes config directory
+# Hermes config directory. HOME is set explicitly because some Hermes voice
+# engines use Path.home() when deriving their cache path.
 RUN mkdir -p /data/hermes /data/hermes/logs /data/hermes/voice_cache
+ENV HOME=/data/hermes
 ENV HERMES_HOME=/data/hermes
 ENV HERMES_VOICE_CACHE=/data/hermes/voice_cache
 

--- a/addon/run.sh
+++ b/addon/run.sh
@@ -17,6 +17,9 @@ MEDIA_PLAYER="$(jq -r '.media_player_entity // ""' /data/options.json)"
 LOG_LEVEL="$(jq -r '.log_level // "info"' /data/options.json)"
 
 # Export for Hermes + plugins
+export HOME="/data/hermes"
+export HERMES_HOME="/data/hermes"
+export HERMES_VOICE_CACHE="/data/hermes/voice_cache"
 export HASS_URL="${HA_URL}"
 export HASS_TOKEN="${SUPERVISOR_TOKEN}"
 export HERMES_HA_WS_HOST="0.0.0.0"


### PR DESCRIPTION
## Summary
- set HOME, HERMES_HOME, and HERMES_VOICE_CACHE to /data/hermes in the Home Assistant add-on
- document the required 7860 port mapping for the HA-facing receiver
- add troubleshooting notes for /root/.hermes/voice_cache permission errors and 7860 port conflicts
- clarify that a Home Assistant Assist conversation-agent platform is not registered yet

Fixes part of #25.

## Verification
- python3 -m compileall -q custom_components plugins tests
- python3 -m pytest tests -q