### PR TITLE
fix: WebSocket reader keep-alive and Assist conversation agent support

### DIFF
--- a/custom_components/hermes/__init__.py
+++ b/custom_components/hermes/__init__.py
@@ -11,11 +11,13 @@ Provides:
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import time
 from datetime import timedelta
 from typing import Any
 
+import aiohttp
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_URL, CONF_TOKEN, Platform
 from homeassistant.core import HomeAssistant
@@ -28,7 +30,7 @@ from .frontend import async_register_resources as _register_frontend
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.CONVERSATION]
 
 # Minimum interval between state-change pushes (seconds)
 _PUSH_INTERVAL = timedelta(seconds=0.2)
@@ -153,6 +155,9 @@ class HermesBridge:
         self._total_interactions = 0
         self._total_errors = 0
         self._voice_ready = False
+        self._reader_task: asyncio.Task | None = None
+        # Map of conversation_id → asyncio.Future for routing Hermes responses
+        self._pending_queries: dict[str, asyncio.Future] = {}
 
     @property
     def connected(self) -> bool:
@@ -169,7 +174,6 @@ class HermesBridge:
             return
 
         # Rate limit per entity
-        import time
         now = time.monotonic()
         last = _LAST_PUSH.get(entity_id, 0)
         if now - last < _PUSH_INTERVAL.total_seconds():
@@ -220,7 +224,6 @@ class HermesBridge:
 
     async def async_connect(self) -> None:
         """Connect to Hermes Agent WebSocket."""
-        import aiohttp
         import ssl as _ssl
 
         ssl_context: _ssl.SSLContext | None = None
@@ -243,6 +246,8 @@ class HermesBridge:
                 heartbeat=30,
             )
             self._connected = True
+            # Start background reader to drain messages and keep heartbeat alive
+            self._reader_task = asyncio.create_task(self._ws_reader())
             _LOGGER.info("Connected to Hermes WebSocket at %s", self.hermes_url)
             # Flush any pending messages queued while disconnected
             await _flush_pending(self._ws, self._pending)
@@ -251,9 +256,102 @@ class HermesBridge:
             self._connected = False
 
 
+    async def _ws_reader(self) -> None:
+        """Background task: continuously drain messages from Hermes WebSocket.
+
+        Keeps the aiohttp heartbeat handling alive and routes
+        conversation responses back to pending query futures.
+        """
+        try:
+            async for msg in self._ws:
+                if msg.type == aiohttp.WSMsgType.TEXT:
+                    try:
+                        data = json.loads(msg.data)
+                    except json.JSONDecodeError:
+                        _LOGGER.debug("Hermes WS: unparseable message")
+                        continue
+                    msg_type = data.get("type", "")
+                    if msg_type == "assist_response":
+                        conv_id = data.get("conversation_id", "")
+                        future = self._pending_queries.pop(conv_id, None)
+                        if future and not future.done():
+                            future.set_result(data)
+                    elif msg_type in ("hermes_event", "state_ack"):
+                        pass  # informational; no routing needed
+                    else:
+                        _LOGGER.debug("Hermes WS: unhandled type=%s", msg_type)
+                elif msg.type == aiohttp.WSMsgType.CLOSED:
+                    _LOGGER.info("Hermes WebSocket closed by server")
+                    break
+                elif msg.type == aiohttp.WSMsgType.ERROR:
+                    _LOGGER.warning("Hermes WebSocket error")
+                    break
+        except asyncio.CancelledError:
+            _LOGGER.debug("Hermes WS reader cancelled")
+        except Exception as exc:
+            _LOGGER.warning("Hermes WS reader exception: %s", exc)
+        finally:
+            self._connected = False
+            # Resolve any pending futures as failed
+            for future in self._pending_queries.values():
+                if not future.done():
+                    future.set_exception(ConnectionError("Hermes WebSocket disconnected"))
+            self._pending_queries.clear()
+
+    async def async_send_conversation_query(
+        self,
+        text: str,
+        conversation_id: str | None = None,
+        language: str = "en",
+    ) -> dict[str, Any]:
+        """Send a conversation query to Hermes and wait for the response.
+
+        Returns the response dict from Hermes (contains 'text' and
+        optionally 'speech' keys).
+        """
+        import uuid
+
+        if conversation_id is None:
+            conversation_id = str(uuid.uuid4())
+
+        payload = {
+            "type": "assist_query",
+            "text": text,
+            "conversation_id": conversation_id,
+            "language": language,
+        }
+
+        future: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._pending_queries[conversation_id] = future
+
+        if self._connected and self._ws:
+            try:
+                await self._ws.send_json(payload)
+            except Exception as exc:
+                self._pending_queries.pop(conversation_id, None)
+                _LOGGER.warning("Failed to send conversation query: %s", exc)
+                raise ConnectionError(f"Failed to send to Hermes: {exc}") from exc
+        else:
+            self._pending_queries.pop(conversation_id, None)
+            raise ConnectionError("Hermes WebSocket not connected")
+
+        try:
+            result = await asyncio.wait_for(future, timeout=30.0)
+            return result
+        except asyncio.TimeoutError:
+            self._pending_queries.pop(conversation_id, None)
+            raise TimeoutError("Hermes did not respond within 30 seconds")
+
     async def async_shutdown(self) -> None:
         """Clean up connections."""
         self._connected = False
+        if self._reader_task and not self._reader_task.done():
+            self._reader_task.cancel()
+            try:
+                await self._reader_task
+            except asyncio.CancelledError:
+                pass
+            self._reader_task = None
         if self._ws:
             await self._ws.close()
             self._ws = None

--- a/custom_components/hermes/conversation.py
+++ b/custom_components/hermes/conversation.py
@@ -1,0 +1,138 @@
+"""Hermes Assist conversation agent for Home Assistant pipelines.
+
+Registers Hermes as a selectable conversation agent in Home Assistant
+Assist, so HA Voice devices can route transcribed text to Hermes and
+receive spoken responses through the configured TTS pipeline.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+try:
+    from homeassistant.components.conversation import (
+        ConversationEntity,
+        ConversationInput,
+        ConversationResult,
+    )
+    from homeassistant.helpers import intent
+except ImportError:  # pragma: no cover - HA stubs / older cores
+    ConversationEntity = object  # type: ignore[misc,assignment]
+    ConversationInput = object  # type: ignore[misc,assignment]
+    ConversationResult = object  # type: ignore[misc,assignment]
+    intent = None  # type: ignore[assignment]
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+AGENT_ID = f"{DOMAIN}_assist"
+AGENT_NAME = "Hermes"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Hermes conversation agent from a config entry."""
+    bridge = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    if bridge is None:
+        _LOGGER.warning("Hermes conversation: no bridge found for entry %s", entry.entry_id)
+        return
+
+    async_add_entities([HermesConversationAgent(bridge, entry.entry_id)])
+
+
+class HermesConversationAgent(ConversationEntity):
+    """Conversation agent that routes Assist pipeline text to Hermes."""
+
+    _attr_has_entity_name = True
+    _attr_name = AGENT_NAME
+    _attr_icon = "mdi:robot"
+
+    def __init__(self, bridge: Any, entry_id: str) -> None:
+        """Initialise the Hermes conversation agent."""
+        self._bridge = bridge
+        self._attr_unique_id = f"{DOMAIN}_{entry_id}_conversation"
+
+    @property
+    def supported_languages(self) -> list[str]:
+        """Return a list of supported languages for this agent."""
+        return ["en"]
+
+    @staticmethod
+    def _make_error_result(
+        language: str,
+        speech: str,
+        conversation_id: str | None = None,
+    ) -> ConversationResult:
+        """Build a ConversationResult with an error speech response."""
+        response = intent.IntentResponse(language=language)
+        response.async_set_speech(speech)
+        return ConversationResult(
+            response=response,
+            conversation_id=conversation_id,
+        )
+
+    async def async_process(self, user_input: ConversationInput) -> ConversationResult:
+        """Process a conversation input from the Assist pipeline.
+
+        Forwards the user text to Hermes over the WebSocket bridge
+        and returns the agent's response.
+        """
+        text = (user_input.text or "").strip()
+        language = getattr(user_input, "language", None) or "en"
+
+        if not text:
+            return self._make_error_result(
+                language,
+                "I didn't catch that. Could you repeat?",
+                user_input.conversation_id,
+            )
+
+        conversation_id = user_input.conversation_id
+
+        try:
+            result = await self._bridge.async_send_conversation_query(
+                text=text,
+                conversation_id=conversation_id,
+                language=language,
+            )
+        except (ConnectionError, TimeoutError) as exc:
+            _LOGGER.warning("Hermes conversation query failed: %s", exc)
+            return self._make_error_result(
+                language,
+                "Sorry, Hermes is not responding right now.",
+                conversation_id,
+            )
+        except Exception as exc:
+            _LOGGER.error("Unexpected error in Hermes conversation: %s", exc)
+            return self._make_error_result(
+                language,
+                "Something went wrong. Please try again.",
+                conversation_id,
+            )
+
+        response_text = result.get("text", "")
+        speech_data = result.get("speech", {})
+        if speech_data:
+            response_speech = speech_data.get("plain", {}).get("speech", response_text)
+        else:
+            response_speech = response_text
+
+        if not response_speech:
+            response_speech = "I processed your request but got no response."
+
+        response = intent.IntentResponse(language=language)
+        response.async_set_speech(response_speech)
+
+        return ConversationResult(
+            response=response,
+            conversation_id=result.get("conversation_id", conversation_id),
+        )


### PR DESCRIPTION
## Summary

Fixes two issues reported by @aaron-agather:

### #27 — WebSocket reader not kept alive
The HA integration opened the aiohttp WebSocket connection to Hermes but had no background reader draining messages, causing the heartbeat to die and `voice_settings` commands to queue instead of sending.

**Changes:**
- Added a `_ws_reader()` background task launched on connect
- Continuously drains messages, keeping aiohttp heartbeat alive
- Sets `_connected = False` when the reader exits
- Cancels the reader task during shutdown
- Also routes `assist_response` messages back to pending conversation query futures

### #28 — Assist conversation agent support
Hermes could not be selected as a conversation agent in HA Assist pipelines. The integration only registered sensors.

**Changes:**
- Added `Platform.CONVERSATION` to `PLATFORMS`
- Created `conversation.py` with `HermesConversationAgent`
- Implements `ConversationEntity.async_process()` — forwards text to Hermes via WebSocket
- Uses future-based request/response routing (query → `assist_query` ws message, response ← `assist_response` ws message)
- Graceful error handling with speech fallbacks when Hermes is unavailable
- `supported_languages` returns `["en"]`

### Protocol notes
The conversation pathway uses two new WebSocket message types:
- **Outgoing** `{"type": "assist_query", "text": "...", "conversation_id": "...", "language": "..."}`
- **Incoming** `{"type": "assist_response", "text": "...", "conversation_id": "...", "speech": {...}}`

The Hermes Agent side will need to handle `assist_query` and respond with `assist_response` for the end-to-end flow to work.

Closes #27
Closes #28