### PR TITLE
Add packaged Hermes plugin installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the hermes-voice-ha-integration project.
 
+## [0.0.10] — 2026-06-15
+
+### Added
+- Packaged `hermes-ha-install-plugins` command for installing the bundled Hermes Agent plugins from the Python wheel or a direct GitHub pip install.
+- Installer tests covering replacement of existing plugin directories and dry-run behaviour.
+
+### Changed
+- Documented the pip-based plugin install and upgrade path, including why existing plugin directories are replaced to avoid stale files.
+- Release metadata is now synchronised across the Python package, HACS manifest, add-on config, and plugin manifests.
+
 ## [0.0.9] — 2026-06-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repository is a bundle of three pieces:
 
 The Python wheel is intentionally plugin-focused. Use the GitHub tag or source distribution for the full HACS/custom-component/add-on bundle.
 
-> **Release:** `v0.0.7` — fixes user-plugin import loading, README install paths, and Home Assistant voice-bridge setup guidance.
+> **Release:** `v0.0.10` — adds a packaged Hermes plugin installer so upgrades replace stale plugin files cleanly.
 
 ---
 
@@ -146,22 +146,40 @@ Keep this token private. It can control your Home Assistant instance with your a
 
 ## Step 3 — Install the Hermes plugins
 
-Clone this repository:
+### Recommended: install from the Python package
+
+Install or upgrade the package directly from GitHub, then run the bundled plugin installer:
+
+```bash
+python3 -m pip install --upgrade "hermes-voice-ha-integration @ git+https://github.com/rusty4444/hermes-voice-ha-integration.git@v0.0.10"
+hermes-ha-install-plugins
+```
+
+The installer copies the packaged `home_assistant` and `voice_stack` plugin directories into `~/.hermes/hermes-agent/plugins`. On upgrade it replaces the existing plugin directories first, so files removed from newer releases do not remain behind from older manual copies.
+
+If your Hermes Agent profile lives somewhere else, pass it explicitly:
+
+```bash
+hermes-ha-install-plugins --profile /path/to/hermes-agent-profile
+```
+
+### Manual source install
+
+If you prefer to inspect or edit the source locally, clone the repository and copy the plugins yourself:
 
 ```bash
 mkdir -p ~/dev
 cd ~/dev
 git clone https://github.com/rusty4444/hermes-voice-ha-integration.git
 cd hermes-voice-ha-integration
-```
 
-Copy the plugins into your Hermes plugin directory:
-
-```bash
 mkdir -p ~/.hermes/hermes-agent/plugins
+rm -rf ~/.hermes/hermes-agent/plugins/home_assistant ~/.hermes/hermes-agent/plugins/voice_stack
 cp -R plugins/home_assistant ~/.hermes/hermes-agent/plugins/home_assistant
 cp -R plugins/voice_stack ~/.hermes/hermes-agent/plugins/voice_stack
 ```
+
+The `rm -rf` lines are intentional during manual upgrades: they avoid leaving stale files behind if a release removes or renames plugin files.
 
 Configure Home Assistant connection details for Hermes. The plugin reads standard environment variables:
 

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,5 +1,5 @@
 name: "Hermes Voice Assistant"
-version: "0.0.8"
+version: "0.0.10"
 slug: "hermes_voice"
 description: "Voice assistant bridge for Home Assistant — wake word → STT → Hermes LLM → TTS → media_player. Can run local-first with local engines."
 url: "https://github.com/rusty4444/hermes-voice-ha-integration"

--- a/custom_components/hermes/manifest.json
+++ b/custom_components/hermes/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/rusty4444/hermes-voice-ha-integration/issues",
   "requirements": [],
-  "version": "0.0.9"
+  "version": "0.0.10"
 }

--- a/plugins/home_assistant/plugin.yaml
+++ b/plugins/home_assistant/plugin.yaml
@@ -1,5 +1,5 @@
 name: home_assistant
-version: 0.0.8
+version: 0.0.10
 description: "Home Assistant plugin for Hermes Agent — bidirectional entity sync, service routing, entity discovery, and compound smart-home tools."
 author: "rusty4444 <rusty4444@users.noreply.github.com>"
 hooks:

--- a/plugins/install_hermes_ha_plugins.py
+++ b/plugins/install_hermes_ha_plugins.py
@@ -1,0 +1,98 @@
+"""Install the Hermes Home Assistant plugins from the Python package.
+
+This module backs the ``hermes-ha-install-plugins`` console command. It copies
+this package's plugin directories into a Hermes Agent profile, replacing any
+previous copies so removed files do not linger after upgrades.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+from pathlib import Path
+
+PLUGIN_NAMES = ("home_assistant", "voice_stack")
+DEFAULT_PROFILE = Path.home() / ".hermes" / "hermes-agent"
+
+
+def _package_plugins_dir() -> Path:
+    return Path(__file__).resolve().parent
+
+
+def _target_plugins_dir(profile: Path) -> Path:
+    return profile.expanduser().resolve() / "plugins"
+
+
+def install_plugins(profile: Path = DEFAULT_PROFILE, *, dry_run: bool = False) -> list[tuple[Path, Path]]:
+    """Install bundled plugin directories into ``profile/plugins``.
+
+    Existing plugin directories with the same names are removed before copying.
+    That replacement behaviour is intentional: it prevents stale files from
+    older releases remaining in a user's Hermes plugin directory.
+    """
+
+    source_root = _package_plugins_dir()
+    target_root = _target_plugins_dir(profile)
+    operations: list[tuple[Path, Path]] = []
+
+    for plugin_name in PLUGIN_NAMES:
+        source = source_root / plugin_name
+        if not source.is_dir():
+            raise FileNotFoundError(f"Packaged plugin directory not found: {source}")
+        operations.append((source, target_root / plugin_name))
+
+    if dry_run:
+        return operations
+
+    target_root.mkdir(parents=True, exist_ok=True)
+    for source, target in operations:
+        if target.exists():
+            if target.is_dir() and not target.is_symlink():
+                shutil.rmtree(target)
+            else:
+                target.unlink()
+        ignore = shutil.ignore_patterns("__pycache__", "*.pyc", ".DS_Store")
+        shutil.copytree(source, target, ignore=ignore)
+
+    return operations
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Install Hermes Home Assistant plugins into a Hermes Agent profile.",
+    )
+    parser.add_argument(
+        "--profile",
+        type=Path,
+        default=Path(os.environ.get("HERMES_PROFILE_DIR", DEFAULT_PROFILE)),
+        help="Hermes Agent profile directory containing the plugins/ folder "
+        "(default: %(default)s).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be copied without writing files.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        operations = install_plugins(args.profile, dry_run=args.dry_run)
+    except Exception as exc:  # noqa: BLE001 - CLI should present concise failure
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    action = "Would install" if args.dry_run else "Installed"
+    for source, target in operations:
+        print(f"{action} {source.name} -> {target}")
+    if not args.dry_run:
+        print("Restart Hermes Agent to load updated plugins.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/voice_stack/plugin.yaml
+++ b/plugins/voice_stack/plugin.yaml
@@ -1,5 +1,5 @@
 name: voice_stack
-version: 0.0.8
+version: 0.0.10
 description: "Local voice pipeline: Wake Word → STT → Hermes LLM → TTS → HA media_player."
 author: "rusty4444 <rusty4444@users.noreply.github.com>"
 hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermes-voice-ha-integration"
-version = "0.0.8"
+version = "0.0.10"
 description = "Home Assistant voice stack integration for Hermes Agent"
 authors = [{name = "Sam Russell", email = "rusty4444@users.noreply.github.com"}]
 license = "MIT"
@@ -10,6 +10,9 @@ dependencies = [
     "aiohttp>=3.9",
     "pydantic>=2.0",
 ]
+
+[project.scripts]
+hermes-ha-install-plugins = "plugins.install_hermes_ha_plugins:main"
 
 [project.optional-dependencies]
 dev = [

--- a/scripts/check_release_integrity.py
+++ b/scripts/check_release_integrity.py
@@ -62,6 +62,7 @@ REQUIRED_FILES = [
 ]
 
 WHEEL_REQUIRED = [
+    "plugins/install_hermes_ha_plugins.py",
     "plugins/home_assistant/plugin.yaml",
     "plugins/home_assistant/README.md",
     "plugins/voice_stack/plugin.yaml",

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -308,7 +308,7 @@ class TestPluginRegistration:
         with open(yaml_path) as f:
             data = yaml.safe_load(f)
         assert data["name"] == "home_assistant"
-        assert data["version"] == "0.0.8"
+        assert data["version"] == "0.0.10"
         assert "on_session_start" in data["hooks"]
 
     def test_voice_stack_plugin_yaml_valid(self):
@@ -318,7 +318,7 @@ class TestPluginRegistration:
         with open(yaml_path) as f:
             data = yaml.safe_load(f)
         assert data["name"] == "voice_stack"
-        assert data["version"] == "0.0.8"
+        assert data["version"] == "0.0.10"
 
 
 # ---------------------------------------------------------------------------
@@ -558,7 +558,7 @@ class TestObservability:
         assert data["domain"] == "hermes"
         assert data["config_flow"] is True
         assert "iot_class" in data
-        assert data["version"] == "0.0.8"
+        assert data["version"] == "0.0.10"
 
     def test_config_flow_translations_are_packaged_for_ha_ui(self):
         """HA must ship runtime translations, not only source strings.json."""
@@ -607,7 +607,7 @@ class TestAddonStructure:
         with open(config_path) as f:
             data = yaml.safe_load(f)
         assert data["name"] == "Hermes Voice Assistant"
-        assert data["version"] == "0.0.8"
+        assert data["version"] == "0.0.10"
         assert data["slug"] == "hermes_voice"
         assert "arch" in data
         assert "amd64" in data["arch"] or "aarch64" in data["arch"]
@@ -826,7 +826,7 @@ class TestVoicePluginInit:
         assert "HERMES_WAKE_WORD_ENGINE" in data["config"]
         assert "HERMES_HA_WS_PORT" in data["config"]
         assert "HERMES_HA_WS_TOKEN" in data["config"]
-        assert data["version"] == "0.0.8"
+        assert data["version"] == "0.0.10"
 
 
 
@@ -1214,7 +1214,7 @@ class TestCHANGELOG:
     def test_changelog_has_version_entries(self):
         cl = Path(__file__).parent.parent / "CHANGELOG.md"
         content = cl.read_text()
-        assert "## [0.0.8]" in content
+        assert "## [0.0.10]" in content
         assert "## [0.0.7]" in content
         assert "## [0.0.6]" in content
 

--- a/tests/test_plugin_installer.py
+++ b/tests/test_plugin_installer.py
@@ -1,0 +1,35 @@
+"""Tests for the packaged Hermes plugin installer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from plugins.install_hermes_ha_plugins import PLUGIN_NAMES, install_plugins
+
+
+def test_install_plugins_replaces_existing_plugin_dirs(tmp_path: Path) -> None:
+    profile = tmp_path / "hermes-agent"
+    plugins_dir = profile / "plugins"
+
+    stale_dir = plugins_dir / "home_assistant"
+    stale_dir.mkdir(parents=True)
+    (stale_dir / "stale_file.py").write_text("old")
+
+    operations = install_plugins(profile)
+
+    assert {target.name for _source, target in operations} == set(PLUGIN_NAMES)
+    for plugin_name in PLUGIN_NAMES:
+        target = plugins_dir / plugin_name
+        assert target.is_dir()
+        assert (target / "plugin.yaml").is_file()
+
+    assert not (stale_dir / "stale_file.py").exists()
+
+
+def test_install_plugins_dry_run_does_not_write(tmp_path: Path) -> None:
+    profile = tmp_path / "hermes-agent"
+
+    operations = install_plugins(profile, dry_run=True)
+
+    assert len(operations) == len(PLUGIN_NAMES)
+    assert not (profile / "plugins").exists()


### PR DESCRIPTION
## Summary
- add a `hermes-ha-install-plugins` console command for installing packaged Hermes plugins into a Hermes Agent profile
- replace existing plugin directories during install so stale files are removed on upgrade
- document the pip/GitHub install path and keep manual copy instructions safe for upgrades
- synchronise release metadata for the next v0.0.10 release

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/test_plugin_installer.py tests/test_release_integrity.py`
- `python3 -m plugins.install_hermes_ha_plugins --dry-run --profile /tmp/hermes-profile-test`

Addresses #30.
