### PR TITLE
Handle Home Assistant Assist query round trips

### DIFF
--- a/docs/ws-protocol.md
+++ b/docs/ws-protocol.md
@@ -101,6 +101,39 @@ Hermes forwards all top-level fields except `type`, `action`, and `args` into th
 
 Response type: `voice_action_result`.
 
+### `assist_query`
+
+Home Assistant Assist sends transcribed user text to Hermes and waits for a
+matching `assist_response`. The receiver routes this through the voice stack
+plugin's Hermes LLM handler, preserving `conversation_id` for the HA-side future.
+
+```json
+{
+  "id": "assist-1",
+  "type": "assist_query",
+  "text": "turn on the kitchen lights",
+  "conversation_id": "01J...",
+  "language": "en"
+}
+```
+
+Response type: `assist_response`.
+
+```json
+{
+  "id": "assist-1",
+  "type": "assist_response",
+  "ok": true,
+  "text": "Done.",
+  "conversation_id": "01J...",
+  "language": "en",
+  "speech": {"plain": {"speech": "Done."}}
+}
+```
+
+The receiver returns an `assist_response` even when the handler is unavailable or
+fails, so Home Assistant receives a spoken fallback instead of timing out.
+
 ## Error shape
 
 Unsupported message types and handler failures return:

--- a/docs/ws-receiver.md
+++ b/docs/ws-receiver.md
@@ -33,9 +33,10 @@ ws://host:7860/api/hermes/ws ──► HermesHAWebSocketServer._handle_ws
                                 └─ handle_voice_action()
                                     └─ _handle_voice_{enable,disable,status}
                                          └─ (returns JSON string)
-  {type: "state_changed"} ──► ack()         ← context buffer | update | store        ──► Hermes event bus  ──► tool_enabled
-  {type: "ping"} ──► pong()
-  {type: "status"} ──► status({uptime, auth_required, counters, connections})
+  {type: "state_changed"} ─► ack()         ← context buffer | update | store        ──► Hermes event bus  ──► tool_enabled
+  {type: "assist_query"} ─► ctx.llm.acomplete() ─► {type: "assist_response"}
+  {type: "ping"} ─► pong()
+  {type: "status"} ─► status({uptime, auth_required, counters, connections})
 ```
 
 ---

--- a/plugins/voice_stack/__init__.py
+++ b/plugins/voice_stack/__init__.py
@@ -333,6 +333,45 @@ def _handle_voice_prompt(args: dict, **kw) -> str:
     return json.dumps({"ok": True, "prompt": prompt})
 
 
+async def _handle_assist_query_with_llm(ctx: Any, payload: dict[str, Any]) -> dict[str, Any]:
+    """Turn an HA Assist query into a Hermes LLM response.
+
+    This handles the HA-side ``assist_query`` message introduced by the
+    conversation platform. It intentionally uses ``ctx.llm`` rather than a
+    placeholder acknowledgement so Home Assistant receives a real spoken reply.
+    """
+    text = str(payload.get("text") or "").strip()
+    language = str(payload.get("language") or "en")
+    conversation_id = payload.get("conversation_id")
+
+    result = await ctx.llm.acomplete(
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "You are Hermes, responding through Home Assistant Assist. "
+                    "Reply naturally and concisely for text-to-speech. "
+                    "If the request needs unavailable context, ask one brief clarification."
+                ),
+            },
+            {
+                "role": "user",
+                "content": f"Language: {language}\nUser request: {text}",
+            },
+        ],
+        max_tokens=512,
+        temperature=0.2,
+        purpose="voice_stack.assist_query",
+    )
+    return {
+        "ok": True,
+        "text": (result.text or "").strip(),
+        "conversation_id": conversation_id,
+        "provider": getattr(result, "provider", None),
+        "model": getattr(result, "model", None),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Tool schemas
 # ---------------------------------------------------------------------------
@@ -459,7 +498,8 @@ def register(ctx) -> None:
     # port is already occupied or aiohttp is unavailable, the warning is logged
     # and normal tool registration still succeeds.
     try:
-        from .ws_receiver import start_ws_receiver
+        from .ws_receiver import set_assist_query_handler, start_ws_receiver
+        set_assist_query_handler(lambda payload: _handle_assist_query_with_llm(ctx, payload))
         start_ws_receiver()
     except Exception as exc:
         logger.warning("Hermes HA WebSocket receiver did not start: %s", exc)

--- a/plugins/voice_stack/ws_receiver.py
+++ b/plugins/voice_stack/ws_receiver.py
@@ -10,11 +10,13 @@ from __future__ import annotations
 
 import asyncio
 import hmac
+import inspect
 import json
 import logging
 import os
 import threading
 import time
+from collections.abc import Awaitable
 from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional
 
 try:
@@ -40,6 +42,8 @@ _START_TIME = time.monotonic()
 _MESSAGE_COUNTERS: dict[str, int] = {}
 _COUNTER_LOCK = threading.Lock()
 _VOICE_ACTION_RESERVED_KEYS = {"type", "action", "args"}
+_AssistQueryHandler = Callable[[dict[str, Any]], Awaitable[dict[str, Any]] | dict[str, Any]]
+_ASSIST_QUERY_HANDLER: Optional[_AssistQueryHandler] = None
 
 
 def _record_message(msg_type: str) -> None:
@@ -52,6 +56,18 @@ def _record_message(msg_type: str) -> None:
 def _message_counters_snapshot() -> dict[str, int]:
     with _COUNTER_LOCK:
         return dict(_MESSAGE_COUNTERS)
+
+
+def set_assist_query_handler(handler: Optional[_AssistQueryHandler]) -> None:
+    """Set the process-local handler for HA Assist query round-trips.
+
+    The WebSocket receiver is intentionally framework-light, so the voice_stack
+    plugin wires this during ``register(ctx)`` with a callback that can access
+    the Hermes plugin context and LLM facade. Tests may pass ``None`` to reset
+    the handler.
+    """
+    global _ASSIST_QUERY_HANDLER
+    _ASSIST_QUERY_HANDLER = handler
 
 
 def receiver_status(server: Optional["HermesHAWebSocketServer"] = None) -> dict[str, Any]:
@@ -165,6 +181,88 @@ def handle_voice_action(payload: dict[str, Any]) -> dict[str, Any]:
         return {"ok": False, "action": action, "error": str(exc)}
 
 
+def _assist_response(
+    payload: dict[str, Any],
+    *,
+    text: str,
+    ok: bool = True,
+    error: str | None = None,
+    extra: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build an ``assist_response`` preserving HA correlation fields."""
+    conversation_id = payload.get("conversation_id")
+    response: dict[str, Any] = {
+        "type": "assist_response",
+        "ok": ok,
+        "text": text,
+        "conversation_id": conversation_id,
+        "language": payload.get("language"),
+        "speech": {"plain": {"speech": text}},
+    }
+    if error:
+        response["error"] = error
+    if extra:
+        response.update(dict(extra))
+    return _with_request_id(payload, response)
+
+
+async def handle_assist_query(payload: dict[str, Any]) -> dict[str, Any]:
+    """Process a Home Assistant Assist query and return ``assist_response``.
+
+    HA's conversation platform sends ``assist_query`` and waits for an
+    ``assist_response`` with the same ``conversation_id``. Returning a typed
+    response even for errors avoids the HA side timing out on unsupported or
+    failed messages.
+    """
+    text = str(payload.get("text") or "").strip()
+    if not text:
+        return _assist_response(
+            payload,
+            ok=False,
+            text="I didn't catch that. Could you repeat?",
+            error="empty assist_query text",
+        )
+
+    handler = _ASSIST_QUERY_HANDLER
+    if handler is None:
+        return _assist_response(
+            payload,
+            ok=False,
+            text="Hermes voice handling is not available right now.",
+            error="assist_query handler is not configured",
+        )
+
+    try:
+        result = handler(payload)
+        if inspect.isawaitable(result):
+            result = await result
+        if not isinstance(result, dict):
+            result = {"text": str(result)}
+        response_text = str(result.get("text") or "").strip()
+        if not response_text:
+            response_text = "I processed that, but did not get a spoken response."
+        extra = {
+            k: v
+            for k, v in result.items()
+            if k not in {"type", "ok", "text", "conversation_id", "language", "speech", "error"}
+        }
+        return _assist_response(
+            payload,
+            ok=bool(result.get("ok", True)),
+            text=response_text,
+            error=result.get("error"),
+            extra=extra,
+        )
+    except Exception as exc:  # pragma: no cover - defensive runtime guard
+        logger.exception("assist_query failed")
+        return _assist_response(
+            payload,
+            ok=False,
+            text="Sorry, Hermes hit an error while processing that.",
+            error=str(exc),
+        )
+
+
 def handle_ha_ws_payload(payload: dict[str, Any]) -> dict[str, Any]:
     """Handle one JSON payload from Home Assistant."""
     msg_type = str(payload.get("type", "")).strip().lower()
@@ -191,6 +289,15 @@ def handle_ha_ws_payload(payload: dict[str, Any]) -> dict[str, Any]:
         return _with_request_id(payload, {"type": "status", **receiver_status()})
 
     return _with_request_id(payload, {"type": "error", "ok": False, "error": f"Unsupported message type: {msg_type or '<missing>'}"})
+
+
+async def handle_ha_ws_payload_async(payload: dict[str, Any]) -> dict[str, Any]:
+    """Async wrapper for payloads that may need a Hermes LLM round-trip."""
+    msg_type = str(payload.get("type", "")).strip().lower()
+    if msg_type == "assist_query":
+        _record_message(msg_type)
+        return await handle_assist_query(payload)
+    return handle_ha_ws_payload(payload)
 
 
 class HermesHAWebSocketServer:
@@ -317,7 +424,7 @@ class HermesHAWebSocketServer:
                         payload = json.loads(msg.data)
                         if not isinstance(payload, dict):
                             raise ValueError("payload must be a JSON object")
-                        response = handle_ha_ws_payload(payload)
+                        response = await handle_ha_ws_payload_async(payload)
                     except Exception as exc:
                         response = {"type": "error", "ok": False, "error": str(exc)}
                     await ws.send_json(response)

--- a/tests/test_ws_receiver.py
+++ b/tests/test_ws_receiver.py
@@ -1,0 +1,144 @@
+"""Tests for the Home Assistant WebSocket receiver."""
+
+from __future__ import annotations
+
+import pytest
+
+from plugins.voice_stack import ws_receiver
+import plugins.voice_stack as voice_stack
+
+
+@pytest.fixture(autouse=True)
+def _reset_assist_handler():
+    ws_receiver.set_assist_query_handler(None)
+    yield
+    ws_receiver.set_assist_query_handler(None)
+
+
+@pytest.mark.asyncio
+async def test_assist_query_returns_response_from_configured_handler():
+    """assist_query should produce assist_response instead of timing out."""
+
+    async def handler(payload: dict) -> dict:
+        assert payload["text"] == "Hello Hermes"
+        return {"text": "Hello from Hermes", "provider": "test-provider"}
+
+    ws_receiver.set_assist_query_handler(handler)
+
+    response = await ws_receiver.handle_ha_ws_payload_async(
+        {
+            "id": "req-1",
+            "type": "assist_query",
+            "text": "Hello Hermes",
+            "conversation_id": "conv-1",
+            "language": "en",
+        }
+    )
+
+    assert response["id"] == "req-1"
+    assert response["type"] == "assist_response"
+    assert response["ok"] is True
+    assert response["text"] == "Hello from Hermes"
+    assert response["conversation_id"] == "conv-1"
+    assert response["speech"]["plain"]["speech"] == "Hello from Hermes"
+    assert response["provider"] == "test-provider"
+
+
+@pytest.mark.asyncio
+async def test_assist_query_without_handler_returns_spoken_fallback():
+    """Missing handler should resolve HA's pending future with a fallback."""
+
+    response = await ws_receiver.handle_ha_ws_payload_async(
+        {
+            "type": "assist_query",
+            "text": "Are you there?",
+            "conversation_id": "conv-2",
+        }
+    )
+
+    assert response["type"] == "assist_response"
+    assert response["ok"] is False
+    assert response["conversation_id"] == "conv-2"
+    assert "not available" in response["text"]
+    assert response["speech"]["plain"]["speech"] == response["text"]
+
+
+@pytest.mark.asyncio
+async def test_assist_query_handler_exception_returns_spoken_error():
+    """Handler exceptions should not fall back to unsupported-message errors."""
+
+    def handler(_payload: dict) -> dict:
+        raise RuntimeError("boom")
+
+    ws_receiver.set_assist_query_handler(handler)
+
+    response = await ws_receiver.handle_ha_ws_payload_async(
+        {
+            "id": "req-3",
+            "type": "assist_query",
+            "text": "break",
+            "conversation_id": "conv-3",
+        }
+    )
+
+    assert response["id"] == "req-3"
+    assert response["type"] == "assist_response"
+    assert response["ok"] is False
+    assert response["error"] == "boom"
+    assert response["conversation_id"] == "conv-3"
+
+
+def test_sync_payload_handler_still_reports_unsupported_for_unknown_types():
+    """Existing synchronous handler semantics are preserved."""
+
+    response = ws_receiver.handle_ha_ws_payload({"id": "x", "type": "banana"})
+
+    assert response == {
+        "id": "x",
+        "type": "error",
+        "ok": False,
+        "error": "Unsupported message type: banana",
+    }
+
+
+@pytest.mark.asyncio
+async def test_voice_stack_assist_handler_uses_ctx_llm():
+    """The registered voice-stack handler should call Hermes plugin LLM access."""
+
+    class _Result:
+        text = "LLM reply"
+        provider = "provider-x"
+        model = "model-y"
+
+    class _Llm:
+        def __init__(self):
+            self.calls = []
+
+        async def acomplete(self, **kwargs):
+            self.calls.append(kwargs)
+            return _Result()
+
+    class _Ctx:
+        def __init__(self):
+            self.llm = _Llm()
+
+    ctx = _Ctx()
+
+    result = await voice_stack._handle_assist_query_with_llm(
+        ctx,
+        {
+            "text": "What is the weather?",
+            "language": "en-AU",
+            "conversation_id": "conv-4",
+        },
+    )
+
+    assert result == {
+        "ok": True,
+        "text": "LLM reply",
+        "conversation_id": "conv-4",
+        "provider": "provider-x",
+        "model": "model-y",
+    }
+    assert ctx.llm.calls[0]["purpose"] == "voice_stack.assist_query"
+    assert "What is the weather?" in ctx.llm.calls[0]["messages"][1]["content"]


### PR DESCRIPTION
## Summary
- add an async `assist_query` handler to the Hermes HA WebSocket receiver
- wire the `voice_stack` plugin to answer Assist queries through `ctx.llm.acomplete`
- return `assist_response` fallbacks instead of unsupported-message errors/timeouts
- document the `assist_query` / `assist_response` protocol

Addresses #33.

## Tests
- `python3 -m pytest tests/test_ws_receiver.py tests/test_plugin.py -q`
- `python3 -m pytest tests/test_release_integrity.py -q`
- `python3 -m py_compile plugins/voice_stack/ws_receiver.py plugins/voice_stack/__init__.py tests/test_ws_receiver.py`

Note: a full local `python3 -m pytest -q` run is blocked by a pre-existing Home Assistant test-environment stub issue where `homeassistant.const.Platform` is a `SimpleNamespace` without `ALARM_CONTROL_PANEL`.
