### PR TITLE
Bump release metadata to v0.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the hermes-voice-ha-integration project.
 
+## [0.0.12] — 2026-06-26
+
+### Fixed
+- Bumped release metadata across the Python package, HACS manifest, add-on config, and bundled Hermes plugins so users can install a version newer than the stale `v0.0.11` tag.
+- Documented the current install tag for the Hermes-side `assist_query` receiver added in PR #35, avoiding the Home Assistant Assist timeout path reported in issue #33.
+
 ## [0.0.10] — 2026-06-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repository is a bundle of three pieces:
 
 The Python wheel is intentionally plugin-focused. Use the GitHub tag or source distribution for the full HACS/custom-component/add-on bundle.
 
-> **Release:** `v0.0.10` — adds a packaged Hermes plugin installer so upgrades replace stale plugin files cleanly.
+> **Release:** `v0.0.12` — ships the Hermes-side `assist_query` receiver and bumps all install surfaces past the stale `v0.0.11` metadata.
 
 ---
 
@@ -151,7 +151,7 @@ Keep this token private. It can control your Home Assistant instance with your a
 Install or upgrade the package directly from GitHub, then run the bundled plugin installer:
 
 ```bash
-python3 -m pip install --upgrade "hermes-voice-ha-integration @ git+https://github.com/rusty4444/hermes-voice-ha-integration.git@v0.0.10"
+python3 -m pip install --upgrade "hermes-voice-ha-integration @ git+https://github.com/rusty4444/hermes-voice-ha-integration.git@v0.0.12"
 hermes-ha-install-plugins
 ```
 

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,5 +1,5 @@
 name: "Hermes Voice Assistant"
-version: "0.0.10"
+version: "0.0.12"
 slug: "hermes_voice"
 description: "Voice assistant bridge for Home Assistant — wake word → STT → Hermes LLM → TTS → media_player. Can run local-first with local engines."
 url: "https://github.com/rusty4444/hermes-voice-ha-integration"

--- a/custom_components/hermes/__init__.py
+++ b/custom_components/hermes/__init__.py
@@ -30,7 +30,8 @@ from .frontend import async_register_resources as _register_frontend
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.CONVERSATION]
+_CONVERSATION_PLATFORM = getattr(Platform, "CONVERSATION", "conversation")
+PLATFORMS: list[Platform | str] = [Platform.SENSOR, _CONVERSATION_PLATFORM]
 
 # Minimum interval between state-change pushes (seconds)
 _PUSH_INTERVAL = timedelta(seconds=0.2)

--- a/custom_components/hermes/manifest.json
+++ b/custom_components/hermes/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/rusty4444/hermes-voice-ha-integration/issues",
   "requirements": [],
-  "version": "0.0.10"
+  "version": "0.0.12"
 }

--- a/plugins/home_assistant/plugin.yaml
+++ b/plugins/home_assistant/plugin.yaml
@@ -1,5 +1,5 @@
 name: home_assistant
-version: 0.0.10
+version: 0.0.12
 description: "Home Assistant plugin for Hermes Agent — bidirectional entity sync, service routing, entity discovery, and compound smart-home tools."
 author: "rusty4444 <rusty4444@users.noreply.github.com>"
 hooks:

--- a/plugins/voice_stack/plugin.yaml
+++ b/plugins/voice_stack/plugin.yaml
@@ -1,5 +1,5 @@
 name: voice_stack
-version: 0.0.10
+version: 0.0.12
 description: "Local voice pipeline: Wake Word → STT → Hermes LLM → TTS → HA media_player."
 author: "rusty4444 <rusty4444@users.noreply.github.com>"
 hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermes-voice-ha-integration"
-version = "0.0.10"
+version = "0.0.12"
 description = "Home Assistant voice stack integration for Hermes Agent"
 authors = [{name = "Sam Russell", email = "rusty4444@users.noreply.github.com"}]
 license = "MIT"

--- a/tests/test_ha_services.py
+++ b/tests/test_ha_services.py
@@ -10,7 +10,31 @@ import pytest
 
 
 def _install_homeassistant_stubs() -> None:
-    """Install minimal HA module stubs so custom-component helpers can import."""
+    """Install minimal HA stubs only when Home Assistant is unavailable.
+
+    The full test suite may run with pytest-homeassistant-custom-component,
+    which imports real Home Assistant modules during fixture setup. Installing
+    partial stubs in that environment replaces ``homeassistant.const.Platform``
+    with a two-value SimpleNamespace and breaks HA's own imports. Prefer the
+    real package when present; keep the lightweight stubs for minimal plugin-only
+    test environments.
+    """
+    try:
+        import homeassistant.components.http as ha_http
+        import homeassistant.config_entries  # noqa: F401
+        import homeassistant.const as ha_const
+        import homeassistant.core  # noqa: F401
+        import homeassistant.helpers.entity  # noqa: F401
+        import homeassistant.helpers.event  # noqa: F401
+        import homeassistant.helpers.typing  # noqa: F401
+    except ImportError:
+        pass
+    else:
+        if hasattr(ha_const, "Platform") and hasattr(ha_const.Platform, "SENSOR"):
+            if not hasattr(ha_http, "StaticPathConfig"):
+                setattr(ha_http, "StaticPathConfig", lambda *a, **k: (a, k))
+            return
+
     modules = {
         "homeassistant": ModuleType("homeassistant"),
         "homeassistant.config_entries": ModuleType("homeassistant.config_entries"),

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -308,7 +308,7 @@ class TestPluginRegistration:
         with open(yaml_path) as f:
             data = yaml.safe_load(f)
         assert data["name"] == "home_assistant"
-        assert data["version"] == "0.0.10"
+        assert data["version"] == "0.0.12"
         assert "on_session_start" in data["hooks"]
 
     def test_voice_stack_plugin_yaml_valid(self):
@@ -318,7 +318,7 @@ class TestPluginRegistration:
         with open(yaml_path) as f:
             data = yaml.safe_load(f)
         assert data["name"] == "voice_stack"
-        assert data["version"] == "0.0.10"
+        assert data["version"] == "0.0.12"
 
 
 # ---------------------------------------------------------------------------
@@ -558,7 +558,7 @@ class TestObservability:
         assert data["domain"] == "hermes"
         assert data["config_flow"] is True
         assert "iot_class" in data
-        assert data["version"] == "0.0.10"
+        assert data["version"] == "0.0.12"
 
     def test_config_flow_translations_are_packaged_for_ha_ui(self):
         """HA must ship runtime translations, not only source strings.json."""
@@ -607,7 +607,7 @@ class TestAddonStructure:
         with open(config_path) as f:
             data = yaml.safe_load(f)
         assert data["name"] == "Hermes Voice Assistant"
-        assert data["version"] == "0.0.10"
+        assert data["version"] == "0.0.12"
         assert data["slug"] == "hermes_voice"
         assert "arch" in data
         assert "amd64" in data["arch"] or "aarch64" in data["arch"]
@@ -826,7 +826,7 @@ class TestVoicePluginInit:
         assert "HERMES_WAKE_WORD_ENGINE" in data["config"]
         assert "HERMES_HA_WS_PORT" in data["config"]
         assert "HERMES_HA_WS_TOKEN" in data["config"]
-        assert data["version"] == "0.0.10"
+        assert data["version"] == "0.0.12"
 
 
 
@@ -991,7 +991,8 @@ class TestSensor:
     def test_platform_listed(self):
         init = Path(__file__).parent.parent / "custom_components" / "hermes" / "__init__.py"
         assert "Platform.SENSOR" in init.read_text()
-        assert "Platform.CONVERSATION" in init.read_text()
+        assert "_CONVERSATION_PLATFORM" in init.read_text()
+        assert 'getattr(Platform, "CONVERSATION", "conversation")' in init.read_text()
 
 
 class TestIsAvailable:


### PR DESCRIPTION
## Summary
- bumps Python package, HACS manifest, add-on config, and bundled Hermes plugin versions to `0.0.12`
- updates the README install command to a tag newer than the stale `v0.0.11` metadata
- adds a changelog entry noting that the Hermes-side `assist_query` receiver from PR #35 is now exposed through current release metadata
- keeps the test suite green by avoiding partial Home Assistant stubs when the real HA package is present, adding a safe `Platform.CONVERSATION` fallback for older HA test packages, and updating release-version assertions

## Why
Issue #33 reports that `v0.0.10` times out because the Hermes-side receiver does not handle `assist_query`. PR #35 added the receiver and `v0.0.11` was tagged, but the install metadata still says `0.0.10`, so users may not get a visible upgrade path. Since `v0.0.11` already exists, this prepares the next clean tag as `v0.0.12` rather than force-moving a tag.

## Verification
- `python3 -m pytest -q` -> `133 passed`
- `python3 scripts/check_release_integrity.py --tag v0.0.12 --no-artifacts` -> `release integrity ok: v0.0.12`