### PR TITLE
fix: Handle Home Assistant Assist queries (assist_query / assist_response round trip)

### DIFF
--- a/docs/ws-protocol.md
+++ b/docs/ws-protocol.md
@@ -101,6 +101,42 @@ Hermes forwards all top-level fields except `type`, `action`, and `args` into th
 
 Response type: `voice_action_result`.
 
+### `assist_query`
+
+Routes a Home Assistant Assist pipeline utterance to Hermes and returns an
+`assist_response` that Home Assistant can speak through the configured pipeline.
+The voice stack plugin installs this handler when it starts the receiver.
+
+```json
+{
+  "id": "assist-1",
+  "type": "assist_query",
+  "text": "turn on the kitchen light",
+  "conversation_id": "ha-conversation-id",
+  "language": "en"
+}
+```
+
+Response type: `assist_response`.
+
+```json
+{
+  "id": "assist-1",
+  "type": "assist_response",
+  "ok": true,
+  "conversation_id": "ha-conversation-id",
+  "language": "en",
+  "text": "Done. The kitchen light is on.",
+  "speech": {"plain": {"speech": "Done. The kitchen light is on.", "extra_data": null}}
+}
+```
+
+By default Assist turns run with the `homeassistant` toolset so the agent can
+use the HA service tools. Set `HERMES_HA_ASSIST_TOOLSETS=config` to use the
+user's configured CLI toolsets instead, or set a comma-separated list such as
+`homeassistant,web`. `HERMES_HA_ASSIST_TIMEOUT` controls the receiver-side
+wait time in seconds before a fallback error response is returned.
+
 ## Error shape
 
 Unsupported message types and handler failures return:

--- a/plugins/voice_stack/__init__.py
+++ b/plugins/voice_stack/__init__.py
@@ -12,6 +12,8 @@ Registered tools:
 
 from __future__ import annotations
 
+import asyncio
+import importlib
 import json
 import logging
 import os
@@ -113,6 +115,64 @@ def _ensure_voice_ready() -> bool:
     if not _voice_ready.is_set():
         return _init_engines()
     return True
+
+
+_ASSIST_AGENT_INSTRUCTIONS = """You are handling a Home Assistant Assist voice request through Hermes.
+Reply in one short, speakable sentence unless you need a brief clarification.
+Use Home Assistant tools when controlling or checking devices. Do not use markdown.
+"""
+
+
+def _assist_toolsets() -> list[str] | None:
+    """Return explicit toolsets for HA Assist turns, or None for user config."""
+    raw = os.getenv("HERMES_HA_ASSIST_TOOLSETS", "homeassistant").strip()
+    if raw.lower() in {"", "config", "default"}:
+        return None
+    return [part.strip() for part in raw.split(",") if part.strip()]
+
+
+def _run_assist_agent(text: str, conversation_id: str | None, language: str) -> str:
+    """Run one non-interactive Hermes turn for an HA Assist query."""
+    _run_agent = getattr(importlib.import_module("hermes_cli.oneshot"), "_run_agent")
+
+    # HA Assist has no interactive approval channel. Home Assistant service
+    # safety is still enforced by the home_assistant plugin allow/block lists.
+    os.environ.setdefault("HERMES_YOLO_MODE", "1")
+    os.environ.setdefault("HERMES_ACCEPT_HOOKS", "1")
+
+    toolsets = _assist_toolsets()
+    prompt = (
+        f"{_ASSIST_AGENT_INSTRUCTIONS}\n"
+        f"Language: {language or 'en'}\n"
+        f"Conversation ID: {conversation_id or 'new'}\n\n"
+        f"User said: {text}"
+    )
+    return _run_agent(
+        prompt,
+        toolsets=toolsets,
+        use_config_toolsets=toolsets is None,
+    )
+
+
+async def _handle_assist_query(payload: dict[str, Any]) -> dict[str, Any]:
+    """Handle HA Assist `assist_query` messages and return `assist_response`."""
+    text = str(payload.get("text") or "").strip()
+    conversation_id = payload.get("conversation_id")
+    language = str(payload.get("language") or "en")
+    timeout = float(os.getenv("HERMES_HA_ASSIST_TIMEOUT", "27"))
+
+    response_text = await asyncio.wait_for(
+        asyncio.to_thread(_run_assist_agent, text, conversation_id, language),
+        timeout=timeout,
+    )
+    response_text = (response_text or "").strip() or "I processed that, but got no response."
+    return {
+        "ok": True,
+        "text": response_text,
+        "conversation_id": conversation_id,
+        "language": language,
+        "speech": {"plain": {"speech": response_text, "extra_data": None}},
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -459,7 +519,8 @@ def register(ctx) -> None:
     # port is already occupied or aiohttp is unavailable, the warning is logged
     # and normal tool registration still succeeds.
     try:
-        from .ws_receiver import start_ws_receiver
+        from .ws_receiver import set_assist_query_handler, start_ws_receiver
+        set_assist_query_handler(_handle_assist_query)
         start_ws_receiver()
     except Exception as exc:
         logger.warning("Hermes HA WebSocket receiver did not start: %s", exc)

--- a/plugins/voice_stack/ws_receiver.py
+++ b/plugins/voice_stack/ws_receiver.py
@@ -10,12 +10,13 @@ from __future__ import annotations
 
 import asyncio
 import hmac
+import inspect
 import json
 import logging
 import os
 import threading
 import time
-from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Mapping, Optional
 
 try:
     from aiohttp import WSMsgType, web
@@ -40,6 +41,9 @@ _START_TIME = time.monotonic()
 _MESSAGE_COUNTERS: dict[str, int] = {}
 _COUNTER_LOCK = threading.Lock()
 _VOICE_ACTION_RESERVED_KEYS = {"type", "action", "args"}
+_MAX_ASSIST_QUERY_CHARS = 4096
+AssistQueryHandler = Callable[[dict[str, Any]], dict[str, Any] | str | Awaitable[dict[str, Any] | str]]
+_ASSIST_QUERY_HANDLER: Optional[AssistQueryHandler] = None
 
 
 def _record_message(msg_type: str) -> None:
@@ -84,6 +88,38 @@ def _with_request_id(payload: dict[str, Any], response: dict[str, Any]) -> dict[
     if "id" in payload and "id" not in response:
         response = {**response, "id": payload["id"]}
     return response
+
+
+def set_assist_query_handler(handler: Optional[AssistQueryHandler]) -> None:
+    """Install the process-local handler for HA Assist conversation queries."""
+    global _ASSIST_QUERY_HANDLER
+    _ASSIST_QUERY_HANDLER = handler
+
+
+def _normalise_assist_response(
+    payload: dict[str, Any],
+    result: dict[str, Any] | str,
+) -> dict[str, Any]:
+    """Coerce a handler result into the HA-side assist_response shape."""
+    conversation_id = payload.get("conversation_id")
+    language = payload.get("language") or "en"
+    if isinstance(result, str):
+        text = result.strip()
+        response: dict[str, Any] = {"ok": True, "text": text}
+    else:
+        response = dict(result)
+        text = str(response.get("text") or response.get("message") or "").strip()
+        response["text"] = text
+        response.setdefault("ok", True)
+
+    response["type"] = "assist_response"
+    response.setdefault("conversation_id", conversation_id)
+    response.setdefault("language", language)
+    response.setdefault(
+        "speech",
+        {"plain": {"speech": response.get("text", ""), "extra_data": None}},
+    )
+    return _with_request_id(payload, response)
 
 
 def _json_loads_maybe(value: Any) -> dict[str, Any]:
@@ -165,6 +201,58 @@ def handle_voice_action(payload: dict[str, Any]) -> dict[str, Any]:
         return {"ok": False, "action": action, "error": str(exc)}
 
 
+async def handle_assist_query(payload: dict[str, Any]) -> dict[str, Any]:
+    """Route a Home Assistant Assist query through the registered Hermes handler."""
+    text = str(payload.get("text") or "").strip()
+    if not text:
+        return _normalise_assist_response(
+            payload,
+            {
+                "ok": False,
+                "text": "I didn't catch that. Could you repeat?",
+                "error": "missing_text",
+            },
+        )
+    if len(text) > _MAX_ASSIST_QUERY_CHARS:
+        payload = {**payload, "text": text[:_MAX_ASSIST_QUERY_CHARS]}
+
+    handler = _ASSIST_QUERY_HANDLER
+    if handler is None:
+        return _normalise_assist_response(
+            payload,
+            {
+                "ok": False,
+                "text": "Hermes Assist is not configured yet.",
+                "error": "assist_handler_unavailable",
+            },
+        )
+
+    try:
+        result = handler(payload)
+        if inspect.isawaitable(result):
+            result = await result
+        return _normalise_assist_response(payload, result)
+    except Exception as exc:  # pragma: no cover - defensive runtime guard
+        logger.exception("assist_query failed")
+        return _normalise_assist_response(
+            payload,
+            {
+                "ok": False,
+                "text": "Sorry, Hermes is not responding right now.",
+                "error": str(exc),
+            },
+        )
+
+
+async def async_handle_ha_ws_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Async dispatcher for payloads that may need an async Assist response."""
+    msg_type = str(payload.get("type", "")).strip().lower()
+    if msg_type == "assist_query":
+        _record_message(msg_type)
+        return await handle_assist_query(payload)
+    return handle_ha_ws_payload(payload)
+
+
 def handle_ha_ws_payload(payload: dict[str, Any]) -> dict[str, Any]:
     """Handle one JSON payload from Home Assistant."""
     msg_type = str(payload.get("type", "")).strip().lower()
@@ -173,6 +261,13 @@ def handle_ha_ws_payload(payload: dict[str, Any]) -> dict[str, Any]:
     if msg_type == "voice_action":
         result = handle_voice_action(payload)
         return _with_request_id(payload, {"type": "voice_action_result", **result})
+
+    if msg_type == "assist_query":
+        return _with_request_id(payload, {
+            "type": "error",
+            "ok": False,
+            "error": "assist_query requires the async WebSocket dispatcher",
+        })
 
     if msg_type == "state_changed":
         # P0 receiver behaviour: acknowledge state pushes so HA knows Hermes
@@ -317,7 +412,7 @@ class HermesHAWebSocketServer:
                         payload = json.loads(msg.data)
                         if not isinstance(payload, dict):
                             raise ValueError("payload must be a JSON object")
-                        response = handle_ha_ws_payload(payload)
+                        response = await async_handle_ha_ws_payload(payload)
                     except Exception as exc:
                         response = {"type": "error", "ok": False, "error": str(exc)}
                     await ws.send_json(response)

--- a/tests/test_ws_receiver.py
+++ b/tests/test_ws_receiver.py
@@ -1,0 +1,69 @@
+"""Tests for the Hermes HA WebSocket receiver."""
+
+from __future__ import annotations
+
+import pytest
+
+from plugins.voice_stack import ws_receiver
+
+
+@pytest.mark.asyncio
+async def test_assist_query_without_handler_returns_assist_response() -> None:
+    ws_receiver.set_assist_query_handler(None)
+
+    response = await ws_receiver.async_handle_ha_ws_payload(
+        {
+            "id": "req-1",
+            "type": "assist_query",
+            "text": "hello",
+            "conversation_id": "conv-1",
+            "language": "en",
+        }
+    )
+
+    assert response["id"] == "req-1"
+    assert response["type"] == "assist_response"
+    assert response["ok"] is False
+    assert response["conversation_id"] == "conv-1"
+    assert response["speech"]["plain"]["speech"] == response["text"]
+    assert response["error"] == "assist_handler_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_assist_query_dispatches_registered_async_handler() -> None:
+    async def handler(payload: dict) -> dict:
+        return {"text": f"Heard: {payload['text']}", "extra": "kept"}
+
+    ws_receiver.set_assist_query_handler(handler)
+    try:
+        response = await ws_receiver.async_handle_ha_ws_payload(
+            {
+                "id": "req-2",
+                "type": "assist_query",
+                "text": "turn on the kitchen light",
+                "conversation_id": "conv-2",
+                "language": "en-AU",
+            }
+        )
+    finally:
+        ws_receiver.set_assist_query_handler(None)
+
+    assert response["id"] == "req-2"
+    assert response["type"] == "assist_response"
+    assert response["ok"] is True
+    assert response["conversation_id"] == "conv-2"
+    assert response["language"] == "en-AU"
+    assert response["text"] == "Heard: turn on the kitchen light"
+    assert response["speech"]["plain"]["speech"] == response["text"]
+    assert response["extra"] == "kept"
+
+
+def test_sync_dispatcher_keeps_assist_query_out_of_unsupported_fallback() -> None:
+    response = ws_receiver.handle_ha_ws_payload(
+        {"id": "req-3", "type": "assist_query", "text": "hello"}
+    )
+
+    assert response["id"] == "req-3"
+    assert response["type"] == "error"
+    assert response["error"] == "assist_query requires the async WebSocket dispatcher"
+    assert "Unsupported message type" not in response["error"]


### PR DESCRIPTION
## Summary

Fixes #33 — the Hermes Agent receiver side now has a full `assist_query` handler so the Home Assistant Assist pipeline round trip works end-to-end.

## What changed

### `ws_receiver.py`
- Adds `async_handle_ha_ws_payload()` as the new async dispatcher (replaces sync `handle_ha_ws_payload()` in the WS message loop)
- Adds `handle_assist_query()` that routes incoming Assist queries to a registered handler
- Adds `set_assist_query_handler()` for the plugin to install its handler
- Adds `_normalise_assist_response()` to coerce handler output into the expected `assist_response` shape
- The sync `handle_ha_ws_payload()` retains an `assist_query` branch that returns a clear error if called from the wrong dispatcher (safety net)

### `voice_stack/__init__.py`
- Adds `_handle_assist_query()` — runs a non-interactive Hermes turn via `hermes_cli.oneshot`
- Configurable toolset scope via `HERMES_HA_ASSIST_TOOLSETS` env var (defaults to `homeassistant`)
- Configurable timeout via `HERMES_HA_ASSIST_TIMEOUT` (defaults to 27s, under the HA-side 30s timeout)

### `docs/ws-protocol.md`
- Documents the `assist_query` / `assist_response` message shapes and env var configuration

### `tests/test_ws_receiver.py`
- Tests for missing handler, registered async handler, and sync dispatcher fallback

## Verification

The HA integration (v0.0.10) sends:
```json
{"type": "assist_query", "text": "...", "conversation_id": "...", "language": "..."}
```

And expects back within 30s:
```json
{"type": "assist_response", "ok": true, "text": "...", "speech": {...}}
```

This PR closes that loop.