### PR TITLE
docs: clarify bundled HA integration compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,17 @@ Home Assistant
 | `voice_listen` | One-shot record + transcription. |
 | `voice_prompt` | Build the voice-optimised prompt with HA context. |
 
+### If you already use Hermes' bundled Home Assistant integration
+
+This project and Hermes' bundled Home Assistant integration can run side by side:
+
+- the bundled integration lets Hermes talk to Home Assistant from inside Hermes chats and skills
+- this project lets Home Assistant talk back to Hermes, including the Assist conversation-agent bridge, status sensors, WebSocket lifecycle, and optional voice-stack helpers
+- existing skills that call the bundled `ha_get_state`, `ha_call_service`, or other built-in HA tools should keep working because this package installs separate plugin directories and does not replace the bundled integration
+- if both integrations expose similarly named tools in your Hermes profile, keep using the tool names your existing skills already reference, or disable one plugin explicitly in `~/.hermes/config.yaml` if you want to avoid overlap
+
+In short: install this when you want Home Assistant to use Hermes as a voice/chat brain. Keep the bundled integration when you want Hermes to operate Home Assistant as a tool provider.
+
 ---
 
 ## Prerequisites


### PR DESCRIPTION
## Summary
- add a README section explaining how this project differs from Hermes' bundled Home Assistant integration
- document that they can run side by side without replacing existing skills that use bundled HA tools
- note when a user should install this project versus relying on the bundled integration

Refs #30.

## Verification
- `uv run --no-project --python /Users/sam.russell/.local/bin/python3.11 --with pytest --with PyYAML --with build python -m pytest tests/test_release_integrity.py -q` -> `6 passed, 1 warning`
