### PR TITLE
fix: make frontend static route registration idempotent

### DIFF
--- a/custom_components/hermes/frontend.py
+++ b/custom_components/hermes/frontend.py
@@ -16,6 +16,7 @@ _CARD_NAME = "hermes-action-bar"
 
 # hacsfiles resource path  (= what appears after /hacsfiles/ in card type)
 _STATIC_URL = "/hermes_static/hermes_action_bar.js"
+_STATIC_PATH_REGISTERED = f"{DOMAIN}_static_path_registered"
 
 # ---------------------------------------------------------------------------
 # Lovelace card resource
@@ -63,9 +64,18 @@ async def async_get_picture_card_content(
 async def async_register_resources(hass) -> None:
     """Serve and register the HermesActionBar card as a dashboard resource."""
     static_path = Path(__file__).parent / "hacsfiles" / "hermes_action_bar.js"
-    await hass.http.async_register_static_paths([
-        StaticPathConfig(_STATIC_URL, str(static_path), cache_headers=True)
-    ])
+    if not hass.data.get(_STATIC_PATH_REGISTERED):
+        try:
+            await hass.http.async_register_static_paths([
+                StaticPathConfig(_STATIC_URL, str(static_path), cache_headers=True)
+            ])
+        except RuntimeError as err:
+            # The route survives a config-entry reload. Newer aiohttp versions
+            # reject registering the same GET route again instead of ignoring it.
+            if "method GET is already registered" not in str(err):
+                raise
+            _LOGGER.debug("Hermes static path is already registered; skipping")
+        hass.data[_STATIC_PATH_REGISTERED] = True
 
     try:
         from homeassistant.components.lovelace import _CONF_RESOURCES as RES_KEY  # type: ignore

--- a/tests/test_ha_services.py
+++ b/tests/test_ha_services.py
@@ -67,6 +67,7 @@ _install_homeassistant_stubs()
 
 from custom_components.hermes.const import DOMAIN, normalize_wake_word
 from custom_components.hermes import services as hermes_services
+from custom_components.hermes.frontend import async_register_resources
 
 
 class FakeServiceRegistry:
@@ -146,6 +147,59 @@ class FakeBridge:
 
     def status_snapshot(self) -> list[dict[str, Any]]:
         return [{"entity_id": "sensor.hermes_voice_ready", "state": "off", "attributes": {}}]
+
+
+class FakeHttp:
+    """Record or fail static-path registrations."""
+
+    def __init__(self, error: RuntimeError | None = None) -> None:
+        self.calls = 0
+        self.error = error
+
+    async def async_register_static_paths(self, paths: list[Any]) -> None:
+        self.calls += 1
+        if self.error is not None:
+            raise self.error
+
+
+@pytest.mark.asyncio
+async def test_frontend_static_path_is_registered_once() -> None:
+    """Config-entry reloads must not register the same aiohttp route twice."""
+    http = FakeHttp()
+    hass = SimpleNamespace(data={}, http=http)
+
+    await async_register_resources(hass)
+    await async_register_resources(hass)
+
+    assert http.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_frontend_tolerates_an_existing_static_route() -> None:
+    """A route left by an earlier setup must not abort integration setup."""
+    http = FakeHttp(
+        RuntimeError(
+            "Added route will never be executed, method GET is already registered"
+        )
+    )
+    hass = SimpleNamespace(data={}, http=http)
+
+    await async_register_resources(hass)
+    await async_register_resources(hass)
+
+    assert http.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_frontend_does_not_hide_unrelated_registration_errors() -> None:
+    """Only the known duplicate-route error is safe to suppress."""
+    http = FakeHttp(RuntimeError("static path is unreadable"))
+    hass = SimpleNamespace(data={}, http=http)
+
+    with pytest.raises(RuntimeError, match="static path is unreadable"):
+        await async_register_resources(hass)
+
+    assert http.calls == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Addresses #43.

Home Assistant config-entry reloads re-run `async_setup_entry`, but aiohttp keeps the existing static GET route and now rejects duplicate registration. This made setup abort before the conversation platform was forwarded.

## Changes

- record process-wide static-path registration in `hass.data`
- skip repeated registration during normal config-entry reloads
- tolerate only aiohttp's known duplicate-GET-route `RuntimeError` when the route predates the guard
- continue raising unrelated static-path registration errors
- add regression coverage for reload, pre-existing route, and unrelated error paths

## Verification

- `uv run --no-project --python ~/.local/bin/python3.11 --with pytest --with pytest-asyncio --with aiohttp --with pydantic --with PyYAML --with build python -m pytest -q` -> `136 passed`
- `python3.11 -m compileall -q custom_components tests`
- `python scripts/check_release_integrity.py --no-artifacts` -> `release integrity ok: v0.0.12`
- `git diff --check`
